### PR TITLE
Add custom CMAKE_MODULE_PATH

### DIFF
--- a/godel_path_planning/CMakeLists.txt
+++ b/godel_path_planning/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(godel_path_planning)
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
 
 find_package(catkin REQUIRED COMPONENTS
   godel_msgs

--- a/godel_process_path_generation/CMakeLists.txt
+++ b/godel_process_path_generation/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(godel_process_path_generation)
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
 
 find_package(catkin REQUIRED COMPONENTS
              roscpp


### PR DESCRIPTION
If the the directory doesn't exist CMake will not throw an error.
For example this allows to add `cmake/Modules/FindEigen.cmake` easily for those who haven't such a file on their system.
