### PR TITLE
Surface Meshing Simplification

### DIFF
--- a/godel_plugins/CMakeLists.txt
+++ b/godel_plugins/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # c++11
-ADD_DEFINITIONS("-std=c++0x")
+#ADD_DEFINITIONS("-std=c++0x")
 
 find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
 

--- a/godel_plugins/CMakeLists.txt
+++ b/godel_plugins/CMakeLists.txt
@@ -10,9 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
 	godel_msgs
 )
 
-# c++11
-#ADD_DEFINITIONS("-std=c++0x")
-
 find_package(Qt4 COMPONENTS QtCore QtGui REQUIRED)
 
 include(${QT_USE_FILE})

--- a/godel_process_path_generation/src/mesh_importer.cpp
+++ b/godel_process_path_generation/src/mesh_importer.cpp
@@ -327,11 +327,6 @@ bool MeshImporter::computePlaneCoefficients(Cloud::ConstPtr cloud, Eigen::Vector
     ROS_WARN("Flipping RANSAC plane normal");
     actual_normal *= -1;
   }
-  //if (actual_normal.dot(expected_normal) < std::cos(seg.getEpsAngle()))
-  //{
-  //  ROS_WARN("RANSAC plane normal out of tolerance! cosines: %f / %f", actual_normal.dot(expected_normal), std::cos(seg.getEpsAngle()));
-  //  return false;
-  //}
 
   output(0) = actual_normal(0);
   output(1) = actual_normal(1);

--- a/godel_process_path_generation/src/mesh_importer.cpp
+++ b/godel_process_path_generation/src/mesh_importer.cpp
@@ -327,11 +327,11 @@ bool MeshImporter::computePlaneCoefficients(Cloud::ConstPtr cloud, Eigen::Vector
     ROS_WARN("Flipping RANSAC plane normal");
     actual_normal *= -1;
   }
-  if (actual_normal.dot(expected_normal) < std::cos(seg.getEpsAngle()))
-  {
-    ROS_WARN("RANSAC plane normal out of tolerance! cosines: %f / %f", actual_normal.dot(expected_normal), std::cos(seg.getEpsAngle()));
-    return false;
-  }
+  //if (actual_normal.dot(expected_normal) < std::cos(seg.getEpsAngle()))
+  //{
+  //  ROS_WARN("RANSAC plane normal out of tolerance! cosines: %f / %f", actual_normal.dot(expected_normal), std::cos(seg.getEpsAngle()));
+  //  return false;
+  //}
 
   output(0) = actual_normal(0);
   output(1) = actual_normal(1);

--- a/godel_surface_detection/CMakeLists.txt
+++ b/godel_surface_detection/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PCL 1.7 REQUIRED COMPONENTS common io)
 find_package(Boost REQUIRED COMPONENTS system)
 
-ADD_DEFINITIONS("-std=c++0x")
+#ADD_DEFINITIONS("-std=c++0x")
 
 set(godel_surface_detection_INCLUDE_DIRECTORIES
 	include

--- a/godel_surface_detection/CMakeLists.txt
+++ b/godel_surface_detection/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(PCL 1.7 REQUIRED COMPONENTS common io)
 find_package(Boost REQUIRED COMPONENTS system)
 
-#ADD_DEFINITIONS("-std=c++0x")
 
 set(godel_surface_detection_INCLUDE_DIRECTORIES
 	include

--- a/godel_surface_detection/include/godel_surface_detection/detection/surface_detection.h
+++ b/godel_surface_detection/include/godel_surface_detection/detection/surface_detection.h
@@ -181,9 +181,7 @@ protected:
 			const Cloud& surface_cluster,Cloud& projected_cluster);
 
 	bool apply_normal_estimation(const Cloud &cloud,Normals& normals);
-	bool apply_fast_triangulation(const Cloud& in,
-			const Normals& normals,
-			pcl::PolygonMesh& mesh);
+	
 	bool apply_kdtree_radius_search(const Cloud& query_points,const Cloud& search_points,double radius,
 			Cloud& close_points);
 
@@ -192,6 +190,13 @@ protected:
 	bool apply_mls_surface_smoothing(const Cloud& cloud_in,Cloud& cloud_out,Normals& normals);
 
 	bool apply_tabletop_segmentation(const Cloud& cloud_in,Cloud& cloud_out);
+
+	/* @brief Finds the best fit plane for the input cloud, reprojects points onto the plane,
+	 * and then calculates the concave hull and triangulates a mesh.
+	 */
+	bool apply_planar_reprojection(const Cloud& in, Cloud& out);
+	bool apply_concave_hull(const Cloud& in, pcl::PolygonMesh& mesh);
+
 
 public:
 

--- a/godel_surface_detection/include/godel_surface_detection/detection/surface_detection.h
+++ b/godel_surface_detection/include/godel_surface_detection/detection/surface_detection.h
@@ -175,8 +175,6 @@ protected:
 	bool apply_region_growing_segmentation(const Cloud& in,
 			const Normals& normals,
 			std::vector<pcl::PointIndices>& clusters,CloudRGB& colored_cloud);
-	bool apply_plane_approximation_refinement(const Cloud& candidates,
-			const Cloud& surface_cluster,Cloud& extended_surface_cluster);
 	bool apply_plane_projection_refinement(const Cloud& candidate_outliers,
 			const Cloud& surface_cluster,Cloud& projected_cluster);
 

--- a/godel_surface_detection/src/detection/surface_detection.cpp
+++ b/godel_surface_detection/src/detection/surface_detection.cpp
@@ -38,6 +38,7 @@
 #include <pcl/surface/concave_hull.h>
 #include <pcl/surface/ear_clipping.h>
 
+const static double CONCAVE_HULL_ALPHA = 0.1;
 
 namespace godel_surface_detection { namespace detection{
 
@@ -477,7 +478,7 @@ bool SurfaceDetection::find_surfaces()
 
 		Cloud::Ptr segment_cloud_ptr = surface_clouds_[i];
 		int count = segment_cloud_ptr->size();
-		//if(apply_plane_approximation_refinement(*ungrouped_cloud_ptr,*segment_cloud_ptr,*segment_cloud_ptr))
+
 		if(apply_plane_projection_refinement(*ungrouped_cloud_ptr,*segment_cloud_ptr,*segment_cloud_ptr))
 		{
 
@@ -634,57 +635,6 @@ bool SurfaceDetection::apply_region_growing_segmentation(const Cloud& in,
 	return clusters.size()>0;
 }
 
-bool SurfaceDetection::apply_plane_approximation_refinement(const Cloud& candidates,
-		const Cloud& surface_cluster,Cloud& extended_surface_cluster)
-{
-	pcl::ModelCoefficients::Ptr coeff_ptr(new pcl::ModelCoefficients());
-	pcl::PointIndices::Ptr plane_inliers_ptr(new pcl::PointIndices());
-	pcl::SACSegmentation<pcl::PointXYZ> seg;
-
-	// setting segmentation options
-	seg.setOptimizeCoefficients(true);
-	seg.setModelType(pcl::SACMODEL_PLANE);
-	seg.setMethodType(pcl::SAC_RANSAC);
-	seg.setMaxIterations(params_.pa_seg_max_iterations);
-	seg.setDistanceThreshold(params_.pa_seg_dist_threshold);
-
-	// finding coefficients
-	seg.setInputCloud(surface_cluster.makeShared());
-	seg.segment(*plane_inliers_ptr,*coeff_ptr);
-
-	// using coefficients to filter out plane
-	pcl::SampleConsensusModelPlane<pcl::PointXYZ> model_plane(candidates.makeShared());
-	Eigen::VectorXf model_coeff(4);
-
-	if(plane_inliers_ptr->indices.size()> 0)
-	{
-		std::vector<int> final_inliers;
-		Cloud::Ptr inlier_points_ptr = Cloud::Ptr(new Cloud());
-		model_plane.setInputCloud(candidates.makeShared());
-		model_coeff<< coeff_ptr->values[0],coeff_ptr->values[1],coeff_ptr->values[2],coeff_ptr->values[3];
-		model_plane.selectWithinDistance(model_coeff,params_.pa_sac_plane_distance,final_inliers);
-		pcl::copyPointCloud(candidates,final_inliers,*inlier_points_ptr);
-
-		// checking distances to main cluster
-		if(apply_kdtree_radius_search(*inlier_points_ptr,surface_cluster,params_.pa_kdtree_radius,*inlier_points_ptr))
-		{
-			// adding to output cloud
-			extended_surface_cluster += *inlier_points_ptr;
-
-			return true;
-		}
-		else
-		{
-			return false;
-		}
-
-	}
-	else
-	{
-		return false;
-	}
-
-}
 
 bool SurfaceDetection::apply_plane_projection_refinement(const Cloud& candidate_outliers,
 		const Cloud& surface_cluster,Cloud& projected_cluster)
@@ -827,7 +777,7 @@ bool SurfaceDetection::apply_tabletop_segmentation(const Cloud& cloud_in,Cloud& 
 	seg.setOptimizeCoefficients(true);
 	seg.setModelType(pcl::SACMODEL_PLANE);
 	seg.setMethodType(pcl::SAC_RANSAC);
-	seg.setMaxIterations (1000);
+	seg.setMaxIterations (params_.pa_seg_max_iterations);
 	seg.setDistanceThreshold(params_.tabletop_seg_distance_threshold);
 	seg.setInputCloud(boost::make_shared<Cloud>(cloud_in));
 	seg.segment(*inliers_ptr,*coeff_ptr);
@@ -855,7 +805,7 @@ bool SurfaceDetection::apply_planar_reprojection(const Cloud& in, Cloud& out)
 	seg.setOptimizeCoefficients(true);
 	seg.setModelType(pcl::SACMODEL_PLANE);
 	seg.setMethodType(pcl::SAC_RANSAC);
-	seg.setMaxIterations(1000);
+	seg.setMaxIterations(params_.pa_seg_max_iterations);
 	seg.setDistanceThreshold(params_.tabletop_seg_distance_threshold);
 
 	// finding coefficients
@@ -886,10 +836,9 @@ bool SurfaceDetection::apply_planar_reprojection(const Cloud& in, Cloud& out)
 bool SurfaceDetection::apply_concave_hull(const Cloud& in, pcl::PolygonMesh& mesh)
 {
 	pcl::PolygonMesh::Ptr mesh_ptr (new pcl::PolygonMesh);
-	static int count = 0;
 	pcl::ConcaveHull<pcl::PointXYZ> chull;
 	chull.setInputCloud (in.makeShared());
-	chull.setAlpha (0.1);
+	chull.setAlpha (CONCAVE_HULL_ALPHA);
 	chull.reconstruct (*mesh_ptr);
 
 	// Given a complex concave hull polygon, seperate it into triangles

--- a/godel_surface_detection/src/services/surface_blending_service.cpp
+++ b/godel_surface_detection/src/services/surface_blending_service.cpp
@@ -548,7 +548,7 @@ protected:
 		switch(req.action)
 		{
 
-		case req.PUBLISH_SCAN_PATH:
+		case godel_msgs::SurfaceDetection::Request::PUBLISH_SCAN_PATH:
 
 			if(req.use_default_parameters)
 			{
@@ -562,7 +562,7 @@ protected:
 			robot_scan_.publish_scan_poses(ROBOT_SCAN_PATH_PREVIEW_TOPIC);
 			break;
 
-		case req.SCAN_AND_FIND_ONLY:
+		case godel_msgs::SurfaceDetection::Request::SCAN_AND_FIND_ONLY:
 
 			if(req.use_default_parameters)
 			{
@@ -579,7 +579,7 @@ protected:
 			res.surfaces.markers.clear();
 			break;
 
-		case req.SCAN_FIND_AND_RETURN:
+		case godel_msgs::SurfaceDetection::Request::SCAN_FIND_AND_RETURN:
 
 			if(req.use_default_parameters)
 			{
@@ -595,7 +595,7 @@ protected:
 			res.surfaces_found =  run_robot_scan(res.surfaces);
 			break;
 
-		case req.FIND_ONLY:
+		case godel_msgs::SurfaceDetection::Request::FIND_ONLY:
 
 			if(req.use_default_parameters)
 			{
@@ -610,7 +610,7 @@ protected:
 			res.surfaces.markers.clear();
 			break;
 
-		case req.FIND_AND_RETURN:
+		case godel_msgs::SurfaceDetection::Request::FIND_AND_RETURN:
 
 			if(req.use_default_parameters)
 			{
@@ -624,7 +624,7 @@ protected:
 			res.surfaces_found =  find_surfaces(res.surfaces);
 			break;
 
-		case req.RETURN_LATEST_RESULTS:
+		case godel_msgs::SurfaceDetection::Request::RETURN_LATEST_RESULTS:
 
 			res = latest_surface_detection_results_;
 			break;
@@ -638,7 +638,7 @@ protected:
 	{
 		switch(req.action)
 		{
-		case req.SELECT:
+		case godel_msgs::SelectSurface::Request::SELECT:
 
 			for(int i = 0; req.select_surfaces.size();i++)
 			{
@@ -646,7 +646,7 @@ protected:
 			}
 			break;
 
-		case req.DESELECT:
+		case godel_msgs::SelectSurface::Request::DESELECT:
 
 			for(int i = 0; req.select_surfaces.size();i++)
 			{
@@ -654,22 +654,22 @@ protected:
 			}
 			break;
 
-		case req.SELECT_ALL:
+		case godel_msgs::SelectSurface::Request::SELECT_ALL:
 
 			surface_server_.select_all(true);
 			break;
 
-		case req.DESELECT_ALL:
+		case godel_msgs::SelectSurface::Request::DESELECT_ALL:
 
 			surface_server_.select_all(false);
 			break;
 
-		case req.HIDE_ALL:
+		case godel_msgs::SelectSurface::Request::HIDE_ALL:
 
 			surface_server_.show_all(false);
 			break;
 
-		case req.SHOW_ALL:
+		case godel_msgs::SelectSurface::Request::SHOW_ALL:
 			surface_server_.show_all(true);
 			break;
 		}
@@ -683,27 +683,27 @@ protected:
 		process_plan.request.params = req.use_default_parameters ? default_blending_plan_params_: req.params;
 		switch(req.action)
 		{
-			case req.GENERATE_MOTION_PLAN:
+			case godel_msgs::ProcessPlanning::Request::GENERATE_MOTION_PLAN:
 				remove_previous_process_plan();
 				res.succeeded = generate_process_plan(process_plan);
 				break;
 
-			case req.GENERATE_MOTION_PLAN_AND_PREVIEW:
+			case godel_msgs::ProcessPlanning::Request::GENERATE_MOTION_PLAN_AND_PREVIEW:
 				remove_previous_process_plan();
 				res.succeeded = generate_process_plan(process_plan) && animate_tool_path();
 				break;
 
-			case req.PREVIEW_TOOL_PATH:
+			case godel_msgs::ProcessPlanning::Request::PREVIEW_TOOL_PATH:
 
 				res.succeeded = animate_tool_path();
 				break;
 
-			case req.PREVIEW_MOTION_PLAN:
+			case godel_msgs::ProcessPlanning::Request::PREVIEW_MOTION_PLAN:
 
 				res.succeeded = false;
 				break;
 
-			case req.EXECUTE_MOTION_PLAN:
+			case godel_msgs::ProcessPlanning::Request::EXECUTE_MOTION_PLAN:
 
 				res.succeeded = false;
 				break;
@@ -723,14 +723,14 @@ protected:
 	{
 		switch(req.action)
 		{
-		case req.GET_CURRENT_PARAMETERS:
+		case godel_msgs::SurfaceBlendingParameters::Request::GET_CURRENT_PARAMETERS:
 
 			res.surface_detection = surface_detection_.params_;
 			res.robot_scan = robot_scan_.params_;
 			res.blending_plan = blending_plan_params_;
 			break;
 
-		case req.GET_DEFAULT_PARAMETERS:
+		case godel_msgs::SurfaceBlendingParameters::Request::GET_DEFAULT_PARAMETERS:
 
 			res.surface_detection = default_surf_detection_params_;
 			res.robot_scan = default_robot_scan_params__;
@@ -793,8 +793,10 @@ int main(int argc,char** argv)
 	ros::AsyncSpinner spinner(4);
 	spinner.start();
 	SurfaceBlendingService service;
+	ROS_INFO("INIT BLENDING SERVICE");
 	if(service.init())
 	{
+		ROS_INFO("BLENDING SERVICE INIT SUCCESSFUL!");
 		service.run();
 	}
 


### PR DESCRIPTION
This pull request is under active development. Please do not merge. I just want it out there for review.

This pull request changes the method of (mesh) triangulation used for surfaces. Once planes of interest are identified, points belonging to them are reprojected onto the plane, the concave hull of all of them is taken, and that is meshed using the ear clipping algorithm. 

This appears to screw up something with normal calculations stored inside the mesh point cloud, so I (dangerously) disabled the check. For the test cases, I've used it still seems to function fine and the plane normals are re-calculated anyway.

Thanks for your patience. 
