### PR TITLE
Add driver node for Keyence LJ-V profilometer

### DIFF
--- a/godel/package.xml
+++ b/godel/package.xml
@@ -8,10 +8,19 @@
 
   <license>Apache2</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>godel_plugins</run_depend>
-	<run_depend>godel_surface_detection</run_depend>
 
-	<export>
-		<metapackage/>
-	</export>
+  <run_depend>godel_sia20d_moveit_config</run_depend>
+  <run_depend>godel_robot_config</run_depend>
+  <run_depend>godel_plugins</run_depend>
+  <run_depend>godel_path_planning</run_depend>
+  <run_depend>godel_process_path_generation</run_depend>
+  <run_depend>godel_msgs</run_depend>
+  <run_depend>godel_keyence_ljv_driver</run_depend>
+  <run_depend>keyence_ljv_description</run_depend>
+  <run_depend>godel_surface_detection</run_depend>
+  <run_depend>godel_polygon_offset</run_depend>
+
+  <export>
+    <metapackage/>
+  </export>
 </package>

--- a/godel_keyence_ljv_driver/CMakeLists.txt
+++ b/godel_keyence_ljv_driver/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(godel_keyence_ljv_driver)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  rospy
+  simple_message
+  pcl_ros
+  dynamic_reconfigure
+)
+
+find_package(Boost COMPONENTS signals)
+
+add_definitions(-DROS=1)
+add_definitions(-DLINUXSOCKETS=1)
+
+generate_dynamic_reconfigure_options(cfg/Keyence.cfg)
+
+catkin_package(
+  CATKIN_DEPENDS roscpp simple_message pcl_ros
+)
+
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
+add_executable(driver_node src/driver.cpp src/ljv7_rawdata.cpp)
+target_link_libraries(driver_node simple_message ${catkin_LIBRARIES})
+add_dependencies(driver_node ${PROJECT_NAME}_gencfg)
+
+install(TARGETS driver_node
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)

--- a/godel_keyence_ljv_driver/README.md
+++ b/godel_keyence_ljv_driver/README.md
@@ -1,0 +1,77 @@
+# Keyence LJ-V driver
+
+This package provides a node that implements a minimal ROS driver for the
+Keyence LJ-V (7000) Ultra-High Speed In-Line Profilometers.
+
+
+## Supported devices
+
+In theory all sensor heads in the LJ-V 7000 product range should be supported,
+but only the V7080 has been tested.
+
+
+## Sensor configuration
+
+As this is not a full fledged driver, the sensor must be configured (with LJ
+Navigator, under Windows) as follows before use with the driver node:
+
+ 1. Continuous Trigger mode, sampling frequency greater than or equal to that
+    configured in the launch file
+ 1. No compression (neither x, nor time)
+ 1. Full width profiles (800 points)
+
+
+## Installation
+
+Clone from source, then build in a catkin workspace. Make sure to check that
+all dependencies have been installed (using `rosdep`).
+
+
+## Use
+
+### Driver node
+Start the driver either directly with the supplied `driver.launch` file, or
+include `driver.launch` in another launch file. In both cases the
+`controller_ip` argument should be provided. All other arguments have default
+values (see `driver.launch` for more information).
+
+After starting the driver, it will immediately connect to the LJ-V controller
+at the configured IP and PORT combination. Only after the `profiles` topic has
+been subscribed to will the driver start communicating with the controller
+however.
+
+All profiles are converted to PCL Point Clouds, published to the configured TF
+frame (by default: `sensor_optical_frame`), which is assumed to exist (the
+driver does not publish any TF frames itself). To correctly place profiles in
+space, the `sensor_optical_frame` should have its origin located at the
+'Reference distance (A)' from the sensor aperture (see the LJ-V Series Setup
+Guide, page 2 for more information). The `keyence_ljv_description` package
+provides a URDF for the LJ-V7080, where the required frames have already been
+defined.
+
+### Coordinate frames
+
+Both the Keyence and ROS use a right-handed coordinate system. However, for the
+sensor, X+ is pointing left, Y+ is back and Z+ is towards the sensor aperture.
+Positive values in the profile are therefore closer to the sensor, negative
+values are further away from it.
+
+### Visualisation of profiles
+
+Visualisation of Point Clouds can be done using the `PointCloud2` visualisation
+Display type in RViz.
+
+Set `Style` to `Points`, and select the appropriate topic. As the published
+profiles are small (maximum of 40 mm across), make sure RViz is zoomed in
+sufficiently.
+
+### Dynamic reconfigure
+
+The driver node has support for dynamic reconfiguration of some of its
+parameters. In particular the `scale_factor` and `cnv_inf_pts` parameters, which
+control the amount of scaling that is performed on profiles before publication,
+and whether profile points reported as having 'infinite distance' by the Keyence
+sensor should have their Z coordinates set to positive infinity (as per
+REP-117), respectively.
+
+By default, no scaling is performed, and the driver honours REP-117.

--- a/godel_keyence_ljv_driver/cfg/Keyence.cfg
+++ b/godel_keyence_ljv_driver/cfg/Keyence.cfg
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+PACKAGE = "godel_keyence_ljv_driver"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+gen.add("scale_factor", double_t, 0, "Scale published clouds with this (all dimensions)", 1.0, 1.0, 100.0)
+gen.add("cnv_inf_pts" , bool_t  , 0, "Report profile points at infinite distances as +Inf (REP-117). If false, mimic LJ Navigator (set to -999.999mm)", True)
+
+exit(gen.generate(PACKAGE, "driver_node", "Keyence"))

--- a/godel_keyence_ljv_driver/include/godel_keyence_ljv_driver/Keyence_tcp_client.h
+++ b/godel_keyence_ljv_driver/include/godel_keyence_ljv_driver/Keyence_tcp_client.h
@@ -1,0 +1,79 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2011, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *       * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *       * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *       * Neither the name of the Southwest Research Institute, nor the names
+ *       of its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GODEL_KEYENCE_LJV_DRIVER_TCP_CLIENT_H
+#define GODEL_KEYENCE_LJV_DRIVER_TCP_CLIENT_H
+
+#include <simple_message/socket/tcp_socket.h>
+#include <simple_message/socket/tcp_client.h>
+
+#include <simple_message/shared_types.h>
+
+#include <simple_message/smpl_msg_connection.h>
+
+
+namespace industrial
+{
+namespace tcp_client
+{
+
+
+/**
+ * \brief Defines TCP client functions.
+ *
+ * public industrial::tcp_socket::TcpSocket
+ */
+class Keyence_TcpClient : public industrial::tcp_client::TcpClient, public industrial::byte_array::ByteArray
+{
+public:
+
+  // Provides SimpleSerialize access to byte array internals
+  //friend class SimpleSerialize;
+
+  /**
+   * \brief Constructor
+   */
+  Keyence_TcpClient(){}
+
+  /**
+   * \brief Destructor
+   */
+  ~Keyence_TcpClient(){}
+
+  bool init(char *buff, int port_num){return industrial::tcp_client::TcpClient::init(buff,port_num);}
+  bool my_sendBytes(industrial::byte_array::ByteArray& buf){return sendBytes(buf);}
+  bool my_receiveBytes(industrial::byte_array::ByteArray& buf, industrial::shared_types::shared_int num_bytes){return receiveBytes(buf, num_bytes);}
+};
+
+} //tcp_client
+} //industrial
+
+#endif /* GODEL_KEYENCE_LJV_DRIVER_TCP_CLIENT_H */

--- a/godel_keyence_ljv_driver/launch/driver.launch
+++ b/godel_keyence_ljv_driver/launch/driver.launch
@@ -1,0 +1,27 @@
+<!--
+  Main driver launch file. Only controller_ip must be specified, all other
+  arguments have defaults.
+-->
+<launch>
+  <arg name="controller_ip"                                  doc="IP address of the Keyence LJ-V7000 controller" />
+  <arg name="controller_port" default="24691"                doc="Standard communication TCP port" />
+  <arg name="head_a_model"    default="V7080"                doc="Model of Head A connected to the controller" />
+  <arg name="cnv_inf_pts"     default="true"                 doc="Report profile points at infinite distances as +Inf (REP-117). If false, mimic LJ Navigator (set to -999.999mm)" />
+  <arg name="scale_factor"    default="1.0"                  doc="Scale all published points clouds by this factor" />
+  <arg name="sample_rate"     default="50"                   doc="Publish rate driver should try to achieve (note: sensor must be configured for at least this rate)" />
+  <arg name="frame_id"        default="sensor_optical_frame" doc="TF frame to publish all profiles in" />
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <node name="keyence_ljv_driver" pkg="godel_keyence_ljv_driver" type="driver_node" launch-prefix="$(arg launch_prefix)">
+    <param name="controller_ip"   type="str"    value="$(arg controller_ip)" />
+    <param name="controller_port" type="int"    value="$(arg controller_port)" />
+    <param name="head_a_model"    type="str"    value="$(arg head_a_model)" />
+    <param name="cnv_inf_pts"     type="bool"   value="$(arg cnv_inf_pts)" />
+    <param name="sample_rate"     type="double" value="$(arg sample_rate)" />
+    <param name="scale_factor"    type="double" value="$(arg scale_factor)" />
+    <param name="frame_id"        type="str"    value="$(arg frame_id)" />
+  </node>
+</launch>

--- a/godel_keyence_ljv_driver/launch/test_v7080_viz.launch
+++ b/godel_keyence_ljv_driver/launch/test_v7080_viz.launch
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="controller_ip" />
+  <arg name="sample_rate" default="100" />
+
+  <include file="$(find godel_keyence_ljv_driver)/launch/driver.launch">
+    <arg name="controller_ip" value="$(arg controller_ip)" />
+    <arg name="sample_rate" value="$(arg sample_rate)" />
+  </include>
+
+  <include file="$(find keyence_ljv_description)/launch/load_lj_v7080.launch" />
+
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <param name="use_gui" value="false" />
+  </node>
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_keyence_ljv_driver)/cfg/rviz.rviz" required="true" />
+</launch>

--- a/godel_keyence_ljv_driver/package.xml
+++ b/godel_keyence_ljv_driver/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package>
+  <name>godel_keyence_ljv_driver</name>
+  <version>0.1.0</version>
+  <description>Minimal ROS driver node for the Keyence LJ-V (7000) Ultra-High Speed In-Line Profilometers.</description>
+  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <license>BSD</license>
+
+  <url type="bugtracker">https://github.com/ros-industrial-consortium/godel/issues</url>
+  <url type="repository">https://github.com/ros-industrial-consortium/godel</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>pcl_ros</build_depend>
+  <build_depend>simple_message</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>pcl_ros</run_depend>
+  <run_depend>simple_message</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
+</package>

--- a/godel_keyence_ljv_driver/src/driver.cpp
+++ b/godel_keyence_ljv_driver/src/driver.cpp
@@ -1,0 +1,557 @@
+/**
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2014, Caterpillar, Inc. (Matthew T. West)
+ * Copyright (c) 2015, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *       * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *       * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *       * Neither the name of the Caterpillar Inc., nor the names
+ *       of its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Minimal, Godel project-specific driver for the Keyence LJ-V (7000) Ultra-High
+ * Speed In-Line Profilometers.
+ *
+ * Tested with LJ-V7080 heads only.
+ *
+ * Uses synchronous GetProfile (0x42) request/reply communication with the
+ * Keyence LJ-V7000 controller.
+ */
+#include <ros/ros.h>
+
+#include <dynamic_reconfigure/server.h>
+#include <godel_keyence_ljv_driver/KeyenceConfig.h>
+
+#include <godel_keyence_ljv_driver/Keyence_tcp_client.h>
+#include <simple_message/byte_array.h>
+
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <sysexits.h>
+
+#include <limits>
+
+// pkg local includes
+#include "ljv7_rawdata.h"
+
+
+
+// keyence protocol / profile related defines
+#define KEYENCE_DEFAULT_TCP_PORT 24691
+#define KEYENCE_DEFAULT_TCP_PORT_HS 24692
+
+#define KEYENCE_RET_CODE_NO_DATA 0xA0
+
+#define KEYENCE_PDEPTH_UNIT 0.01d // in micro meters
+
+// TODO: only a difference of 2; most likely some (undocumented) flag?
+#define KEYENCE_INFINITE_DISTANCE_VALUE -524288
+#define KEYENCE_INFINITE_DISTANCE_VALUE2 -524286
+
+// values LJ Navigator uses for out-of-range points (in meters)
+#define KEYENCE_INFINITE_DISTANCE_VALUE_SI  -999.9990d / 1e3
+#define KEYENCE_INFINITE_DISTANCE_VALUE_SI2 -999.9970d / 1e3
+
+
+// default values for parameters
+#define DEFAULT_SAMPLE_RATE 10.0
+#define DEFAULT_FRAME_ID "sensor_optical_frame"
+
+
+// error codes for receive_get_profile_response(..)
+#define RESP_ERR_OK 0
+#define RESP_ERR_PFX_LEN 1
+#define RESP_ERR_UNL_PFX_LEN 2
+#define RESP_ERR_PKT_BUFF_OVERFLOW 3
+#define RESP_ERR_RECV_PAYLOAD 4
+#define RESP_ERR_EAGAIN 5
+#define RESP_ERR_BRC 6
+#define RESP_ERR_ABN_BODY_LEN 7
+#define RESP_ERR_HDR_RET_CODE 8
+
+
+// local types
+typedef pcl::PointCloud<pcl::PointXYZ> point_cloud_t;
+
+typedef struct
+{
+  profile_point_t* points; // array with unpacked data points
+  uint32_t num_points;     // number of data points in array
+  uint16_t data_unit;      // 'profile data unit' (see excel sheet)
+  int32_t x_start;         // '1st point X coordinate' (see excel sheet)
+  int32_t x_increment;     // 'profile data X direction interval' (see excel sheet)
+} keyence_profile_t;
+
+typedef struct
+{
+  double pc_scale_factor;
+  bool cnv_inf_pts;
+} config_t;
+
+
+/**
+ * Extract type at 'offset' into byte array pointed to by 'buf'.
+ */
+template <typename T>
+static T extract_field(unsigned char* buf, uint32_t offset) { return ( *((T*) (buf+offset))); }
+
+
+// prototypes
+bool send_get_profile_request(industrial::tcp_client::Keyence_TcpClient& tcp_client);
+int receive_get_profile_response(industrial::tcp_client::Keyence_TcpClient& tcp_client, unsigned char* response_data, uint32_t* response_data_sz);
+int unpack_response_command_data(unsigned char* cmd_data, uint32_t cmd_data_sz, keyence_profile_t& profile);
+int keyence_profile_to_pc(keyence_profile_t& profile, point_cloud_t::Ptr msg, bool cnv_inf_pts, double scale_factor);
+
+
+// TODO: refactor node to (a) proper clas(ses), avoid global variables
+config_t config_;
+
+void dr_callback(godel_keyence_ljv_driver::KeyenceConfig &config, uint32_t level)
+{
+  ROS_DEBUG("Reconfigure Request (scale_factor: %.2f; "
+    "cnv_inf_pts: %s)", config.scale_factor, config.cnv_inf_pts ? "true" : "false");
+
+  config_.pc_scale_factor = config.scale_factor;
+  config_.cnv_inf_pts = config.cnv_inf_pts;
+}
+
+
+int main(int argc, char** argv)
+{
+  ros::init (argc, argv, "keyence_lj_driver");
+  ros::NodeHandle nh, pnh("~");
+
+  // ros parameters
+  std::string sensor_host;
+  std::string head_a_model;
+  std::string frame_id;
+  int sensor_port;
+  double sample_rate;
+
+  // simple message socket comm
+  industrial::tcp_client::Keyence_TcpClient tcp_client;
+  unsigned char response_data[4096]; // TODO: magic nr
+  uint32_t response_data_sz = 0;
+  keyence_profile_t profile;
+
+  // init profile var
+  memset(&profile, 0, sizeof(keyence_profile_t));
+
+  // dynamic reconfigure init
+  dynamic_reconfigure::Server<godel_keyence_ljv_driver::KeyenceConfig> dr_server(pnh);
+  dynamic_reconfigure::Server<godel_keyence_ljv_driver::KeyenceConfig>::CallbackType f;
+  f = boost::bind(&dr_callback, _1, _2);
+  dr_server.setCallback(f);
+
+  // param init.
+  // check required parameters
+  if (!pnh.hasParam("controller_ip"))
+  {
+    ROS_FATAL("Parameter 'controller_ip' missing. Cannot continue.");
+    return EX_CONFIG;
+  }
+  if (!pnh.hasParam("head_a_model"))
+  {
+    ROS_FATAL("Parameter 'head_a_model' missing. Cannot continue.");
+    return EX_CONFIG;
+  }
+
+  pnh.getParam("controller_ip", sensor_host);
+  pnh.getParam("head_a_model", head_a_model);
+  pnh.param("controller_port", sensor_port, KEYENCE_DEFAULT_TCP_PORT);
+  pnh.param("sample_rate", sample_rate, DEFAULT_SAMPLE_RATE);
+  pnh.param<std::string>("frame_id", frame_id, DEFAULT_FRAME_ID);
+
+  ROS_INFO("Connecting to %s (TCP %d), expecting a single %s head",
+    sensor_host.c_str(), sensor_port, head_a_model.c_str());
+
+  ROS_INFO("Scaling profiles %.2f times", config_.pc_scale_factor);
+  ROS_INFO("Attempting to publish at %.2f Hz", sample_rate);
+
+  if (config_.cnv_inf_pts)
+    ROS_INFO("Profile points at infinite distances published with Z: +Inf (REP-117)");
+  else
+    ROS_INFO("Profile points at infinite distances published with Z: %.2f (m)",
+      KEYENCE_INFINITE_DISTANCE_VALUE_SI);
+
+  // setup point cloud message (we reuse single one)
+  // TODO: this won't work with nodelets
+  point_cloud_t::Ptr pc_msg(new point_cloud_t);
+  pc_msg->header.frame_id = frame_id;
+  // message is essentially a line-strip of points
+  pc_msg->height = 1;
+
+  // set up profile cloud publisher
+  ros::Publisher pub = nh.advertise<point_cloud_t>("profiles", 10);
+
+  // socket comm init
+  tcp_client.init(const_cast<char*>(sensor_host.c_str()), sensor_port);
+  if (!tcp_client.makeConnect())
+  {
+    ROS_FATAL("Could not connect to controller at %s (TCP %d). Aborting",
+      sensor_host.c_str(), sensor_port);
+    return EX_IOERR;
+  }
+
+
+  /**
+   * Main loop:
+   *
+   *  1. send GetProfile request
+   *  2. receive GetProfile response
+   *  3. unpack profile data
+   *  4. convert to point cloud
+   *  5. publish
+   */
+  int res = 0;
+  ros::Rate sleeper(sample_rate);
+  while(ros::ok() /* && still connected*/)
+  {
+    // sleep?
+    sleeper.sleep();
+
+    // for dynamic reconfigure
+    ros::spinOnce();
+
+    // avoid interacting with sensor if there are no publishers
+    // TODO: maybe we should actually always poll sensor, but just not
+    //       publish anything (although unpacking + publishing is cheap)
+    if (pub.getNumSubscribers() == 0)
+    {
+      ROS_INFO_THROTTLE(60, "No (more) subscribers. Not polling sensor.");
+      continue;
+    }
+
+    if(!send_get_profile_request(tcp_client))
+    {
+      ROS_FATAL("Sending GetProfile request failed. Aborting");
+      break;
+    }
+
+    if((res = receive_get_profile_response(tcp_client, response_data, &response_data_sz)) < 0)
+    {
+      if (res == -RESP_ERR_EAGAIN)
+      {
+        // Warn user at maximum rate of 1 msg per second, so as to not swamp
+        // the terminal / log (too much)
+        ROS_WARN_THROTTLE(1, "Sensor out-of-data, backing off (sampling rate too high?)");
+        // and try again later
+        continue;
+      }
+
+      ROS_FATAL("Receiving GetProfile response failed. Aborting");
+      break;
+    }
+
+    // unpack profile data
+    memset(profile.points, 0, profile.num_points * sizeof(profile_point_t));
+    res = unpack_response_command_data(response_data, response_data_sz, profile);
+    if (res < 0)
+    {
+      ROS_WARN("Problem unpacking GetProfile response data, ignoring profile (err: %d)", res);
+      continue;
+    }
+
+    // convert to pointcloud
+    pc_msg->points.clear();
+    res = keyence_profile_to_pc(profile, pc_msg, config_.cnv_inf_pts, config_.pc_scale_factor);
+    // res can only be 0 here
+
+    // publish pointcloud
+    pub.publish(pc_msg);
+  }
+
+  // TODO: socket should be properly closed here, but
+  //       industrial::tcp_client::TcpClient doesn't seem to allow us?
+
+  return EX_OK;
+}
+
+
+bool send_get_profile_request(industrial::tcp_client::Keyence_TcpClient& tcp_client)
+{
+  // TODO: lots of magic nrs (protocol constants)
+  industrial::byte_array::ByteArray buf;
+  buf.init();
+
+  // setup pkt according to documentation
+  buf.load(0x00000020); // total pkt length: 32 bytes
+
+  buf.load(0x00F00001); // it's a request & pkg version
+  buf.load(       0x0); // 'fixed as 0x00'
+  buf.load(0x00000014); // body length: 20 bytes
+
+  buf.load(      0x42); // command code: get profile
+
+  buf.load(       0x0); // profile bank: active surface (page 9, comm lib refman)
+  buf.load(       0x0); // profile pos : from current (page 9, comm lib refman)
+  buf.load(       0x1); // nr of profile (how many profiles do we want in a single reply)
+  buf.load(0x00000101); // last bits: 'nr of demanded profile' & 'erase reading data'
+                        // 'nr of demanded profile' only valid/necessary when 'profile pos'
+                        // has been set to '2: specify position'
+                        // 'erase reading data' will remove the profile after
+                        // it has been read
+
+  ROS_DEBUG("Sending GetProfile (%d bytes)", buf.getBufferSize());
+
+  return tcp_client.my_sendBytes(buf);
+}
+
+
+/**
+ * Returns the 'response data' part of a GetProfile reply
+ */
+int receive_get_profile_response(industrial::tcp_client::Keyence_TcpClient& tcp_client, unsigned char* response_data, uint32_t* response_data_sz)
+{
+  // TODO: magic nr: large 'enough'
+  const uint32_t buf_sz = 4096;
+  unsigned char buf[buf_sz];
+  uint32_t buf_ptr = 0;
+  uint32_t pkt_len = 0;
+
+  industrial::byte_array::ByteArray barray;
+  barray.init();
+
+  // first receive prefix.pkt_len, so we know how large pkt is
+  if(!tcp_client.my_receiveBytes(barray, sizeof(pkt_len)))
+  {
+    ROS_ERROR("Error receiving prefix.pkt_len. Aborting");
+    return -RESP_ERR_PFX_LEN;
+  }
+
+  ROS_DEBUG("raw pkt_len: 0x%X", *((uint32_t*)barray.getRawDataPtr()));
+
+  if(!barray.unload(&pkt_len, sizeof(pkt_len)))
+  {
+    ROS_ERROR("Error unloading prefix.pkt_len. Aborting");
+    return -RESP_ERR_UNL_PFX_LEN;
+  }
+
+  if(pkt_len >= buf_sz)
+  {
+    ROS_ERROR("Incoming pkt too large for buffer (%d > %d). Aborting",
+      pkt_len, buf_sz);
+    return -RESP_ERR_PKT_BUFF_OVERFLOW;
+  }
+
+  // now wait for at least enough for pkt_len
+  while (buf_ptr < pkt_len)
+  {
+    barray.init();
+    const uint32_t to_receive = std::min<uint32_t>(pkt_len - buf_ptr, barray.getMaxBufferSize());
+    ROS_DEBUG("Reading %d bytes from socket", to_receive);
+
+    // TODO: This is blocking, no way to timeout from this
+    if(!tcp_client.my_receiveBytes(barray, to_receive))
+    {
+      ROS_ERROR("Error receiving GetProfile response part. Aborting");
+      return -RESP_ERR_RECV_PAYLOAD;
+    }
+
+    // assume we have the number of bytes we requested (TODO: make sure we do)
+    memcpy(&buf[buf_ptr], barray.getRawDataPtr(), to_receive);
+    buf_ptr += to_receive;
+  }
+
+  if (buf_ptr > pkt_len)
+  {
+    ROS_WARN("GetProfile response was larger than "
+      "expected (%d > %d)", buf_ptr, pkt_len);
+  }
+
+  // extract fields from raw pkt data
+  const uint8_t  return_code = extract_field<uint8_t>(buf, 4);
+  const uint32_t body_length = extract_field<uint32_t>(buf, 8);
+
+  ROS_DEBUG("GetProfile response with %d retcode. Body length: %d",
+    return_code, body_length);
+
+  // check reply, make sure we got what we expected
+  // TODO: magic nr
+  if (return_code != 0)
+  {
+    ROS_WARN("Received unexpected return code "
+      "from sensor for GetProfile: 0x%02X", return_code);
+    return -RESP_ERR_HDR_RET_CODE;
+  }
+
+  // see if we have enough to check the 'body return code'
+  if (body_length >= 2)
+  {
+    // 12 bytes of response header, +1 for the 'command code' byte
+    // in the response body
+    const uint8_t body_return_code  = extract_field<uint8_t>(buf, 13);
+
+    if (body_return_code == KEYENCE_RET_CODE_NO_DATA)
+    {
+      return -RESP_ERR_EAGAIN;
+    }
+    else if (body_return_code != 0)
+    {
+      ROS_WARN("GetProfile response error: 0x%02X.", body_return_code);
+      return -RESP_ERR_BRC;
+    }
+  }
+
+  // TODO: magic (and arbitrary) nr
+  if (body_length < 512 /*bytes*/)
+  {
+    ROS_WARN("Abnormal (for GetProfile) body length encountered "
+      "(%d bytes), ignoring response", body_length);
+    return -RESP_ERR_ABN_BODY_LEN;
+  }
+
+  // everything ok: extract response body data for caller
+  const uint32_t pfx_len = 4;
+  const uint32_t hdr_len = 12;
+  const uint32_t resp_body_bits_len = 12; // response body without response data
+
+  const uint32_t command_data_offset = hdr_len + resp_body_bits_len;
+  const uint32_t command_data_sz = body_length - resp_body_bits_len;
+
+  memcpy(response_data, &buf[command_data_offset], command_data_sz);
+
+  // done
+  return RESP_ERR_OK;
+}
+
+
+// assumption: 'profile' already initialised, with 'points' array already alloc-ed
+// assumption2: single head, no compression
+int unpack_response_command_data(unsigned char* cmd_data, uint32_t cmd_data_sz, keyence_profile_t& profile)
+{
+  /* Need:
+   *  - number of profile points
+   *  - data unit
+   *  - x_start
+   *  - x_increment
+   *  - unpacked points
+   */
+
+  // all offsets relative to start of response data
+  const uint32_t profile_info_sz = 12;
+  const uint32_t profile_info_offset = 24;
+  const uint32_t profile_data_offset = profile_info_offset + profile_info_sz;
+
+  // get at profile information within response data
+  unsigned char* profile_info = cmd_data + profile_info_offset;
+
+  // get at profile data within response data
+  unsigned char* profile_data = cmd_data + profile_data_offset;
+
+  // get at point data within profile data
+  const uint32_t point_data_offset = 24; // relative to profile_data start
+  unsigned char* point_data = profile_data + point_data_offset;
+
+  // get simple fields
+  profile.num_points  = extract_field<uint16_t>(profile_info, 0);
+  profile.data_unit   = extract_field<uint16_t>(profile_info, 2);
+  profile.x_start     = extract_field<int32_t> (profile_info, 4);
+  profile.x_increment = extract_field<int32_t> (profile_info, 8);
+
+  // check
+  if (profile.points == NULL)
+  {
+    // TODO: this leaks (but only minor)
+    // TODO: this also assumes that 'num_points' can't change during a run
+    //       (which is true, as long as we don't allow / expect any config
+    //        changes to the sensor during a run).
+    profile.points = new profile_point_t[profile.num_points]();
+  }
+
+  const uint32_t trigger_count = extract_field<uint32_t>(profile_data, 4);
+  const uint32_t encoder_count = extract_field<uint32_t>(profile_data, 8);
+
+  ROS_DEBUG("Unpacking profile %d. Nr of points: %d; data unit: %d; X Start: %d; X Incr: %d",
+    trigger_count, profile.num_points, profile.data_unit, profile.x_start, profile.x_increment);
+
+  // unpack profile points
+  // TODO: hard coded point_data sz (should calculate from pointers)
+  const uint32_t point_data_sz = 2000; // bytes
+  int res = ljv7_unpack_profile_data(point_data, point_data_sz,
+    profile.num_points, profile.points, (profile.num_points * sizeof(profile_point_t)));
+
+  if (res != 0)
+  {
+    ROS_WARN("Error unpacking profile data (err: %d). Ignoring profile %d",
+      res, trigger_count);
+    return res;
+  }
+
+  // done
+  return 0;
+}
+
+
+// assumption: 'msg' is a properly setup (and empty) PointCloud msg
+int keyence_profile_to_pc(keyence_profile_t& profile, point_cloud_t::Ptr msg, bool cnv_inf_pts, double scale_factor)
+{
+  // TODO: get proper timestamp from somewhere
+  // pcl header stamps are in microseconds
+  msg->header.stamp = ros::Time::now().toNSec()/1e3;
+  msg->width = profile.num_points;
+
+  const double x_start = (profile.x_start * KEYENCE_PDEPTH_UNIT);
+  double x = 0., y = 0., z = 0.;
+
+  // add points
+  for (unsigned int i = 0; i < profile.num_points; ++i)
+  {
+    // convert profile points to SI units (meters)
+    x = (x_start + (i * (profile.x_increment * KEYENCE_PDEPTH_UNIT))) / 1e6;
+    y = 0.;
+    z = ((profile.data_unit * KEYENCE_PDEPTH_UNIT) * profile.points[i]) / 1e6;
+
+    // filter out 'infinite distance' points
+    // REP-117: http://www.ros.org/reps/rep-0117.html
+    //  "out of range detections will be represented by +Inf."
+    if(profile.points[i] == KEYENCE_INFINITE_DISTANCE_VALUE)
+    {
+      if (cnv_inf_pts)
+        z = std::numeric_limits<double>::infinity();
+      else
+        z = KEYENCE_INFINITE_DISTANCE_VALUE_SI;
+    }
+
+    // device returns two different values that are supposed to be interpreted
+    // as out-of-range or 'infinite'. This is the second
+    if(profile.points[i] == KEYENCE_INFINITE_DISTANCE_VALUE2)
+    {
+      if (cnv_inf_pts)
+        z = std::numeric_limits<double>::infinity();
+      else
+        z = KEYENCE_INFINITE_DISTANCE_VALUE_SI2;
+    }
+
+    x *= scale_factor;
+    y *= scale_factor;
+    z *= scale_factor; // 'inf * something' still inf
+
+    msg->points.push_back(pcl::PointXYZ(x, y, z));
+  }
+
+  return 0;
+}

--- a/godel_keyence_ljv_driver/src/ljv7_rawdata.cpp
+++ b/godel_keyence_ljv_driver/src/ljv7_rawdata.cpp
@@ -1,0 +1,98 @@
+/**
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2015, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *       * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *       * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *       * Neither the name of the Southwest Research Institute, nor the names
+ *       of its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ljv7_rawdata.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <limits.h>
+
+
+int ljv7_unpack_profile_data(unsigned char* src, uint32_t src_sz, uint32_t num_pp, profile_point_t* dst, uint32_t dst_sz)
+{
+  // constants from protocol documentation
+  const uint32_t bpp = 20; // bits per profile point
+  const uint32_t ppr =  8; // profiles per 'row'
+
+  const uint32_t bpb = sizeof(char) * CHAR_BIT; // bits per byte
+  const uint32_t bpr = (bpp * ppr) / bpb; // bytes per 'row'
+  const uint32_t ipr = bpr / sizeof(int32_t); // ints per 'row'
+  unsigned int i = 0, j = 0;
+
+  // make sure source buffer is multiple of 'bytes per row' bytes
+  if (src_sz % bpr != 0)
+  {
+    return -1;
+  }
+
+  // make sure destination buffer is large enough to hold unpacked data
+  if (dst_sz != (num_pp * sizeof(profile_point_t)))
+  {
+    return -2;
+  }
+
+  const unsigned char* src_end = src + ((num_pp * bpp) / 8);
+  if (src_end > (src + src_sz))
+  {
+    // TODO: define our own internal error codes
+    return -3;
+  }
+
+  uint32_t* ints_ptr = (uint32_t*) src;
+  // from: https://graphics.stanford.edu/~seander/bithacks.html#FixedSignExtend
+  const int32_t m = 1U << (bpp - 1);
+  for (i = 0, j = 0; j < num_pp; i+=ipr, j+=ppr)
+  {
+    // unpack 'ppr' points at a time (which needs 'ipr' int32's)
+    dst[j    ] = ((ints_ptr[i  ] & 0x000FFFFF));
+    dst[j + 1] = ((ints_ptr[i  ] & 0xFFF00000) >> 20) | ((ints_ptr[i+1] & 0x000000FF) << 12);
+    dst[j + 2] = ((ints_ptr[i+1] & 0x0FFFFF00) >>  8);
+    dst[j + 3] = ((ints_ptr[i+1] & 0xF0000000) >> 28) | ((ints_ptr[i+2] & 0x0000FFFF) <<  4);
+
+    dst[j + 4] = ((ints_ptr[i+2] & 0xFFFF0000) >> 16) | ((ints_ptr[i+3] & 0x0000000F) << 16);
+    dst[j + 5] = ((ints_ptr[i+3] & 0x00FFFFF0) >>  4);
+    dst[j + 6] = ((ints_ptr[i+3] & 0xFF000000) >> 24) | ((ints_ptr[i+4] & 0x00000FFF) <<  8);
+    dst[j + 7] = ((ints_ptr[i+4] & 0xFFFFF000) >> 12);
+
+    // todo: rework this
+    dst[j    ] = (dst[j] ^ m) - m;
+    dst[j + 1] = (dst[j + 1] ^ m) - m;
+    dst[j + 2] = (dst[j + 2] ^ m) - m;
+    dst[j + 3] = (dst[j + 3] ^ m) - m;
+    dst[j + 4] = (dst[j + 4] ^ m) - m;
+    dst[j + 5] = (dst[j + 5] ^ m) - m;
+    dst[j + 6] = (dst[j + 6] ^ m) - m;
+    dst[j + 7] = (dst[j + 7] ^ m) - m;
+  }
+
+  return 0;
+}

--- a/godel_keyence_ljv_driver/src/ljv7_rawdata.h
+++ b/godel_keyence_ljv_driver/src/ljv7_rawdata.h
@@ -1,0 +1,45 @@
+/**
+ * Software License Agreement (BSD License)
+ *
+ * Copyright (c) 2015, Southwest Research Institute
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *       * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *       * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *       * Neither the name of the Southwest Research Institute, nor the names
+ *       of its contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef __KEYENCE_DRIVER_LJV7_RAWDATA_H__
+#define __KEYENCE_DRIVER_LJV7_RAWDATA_H__
+
+
+#include <stddef.h>
+#include <stdint.h>
+
+
+typedef int32_t profile_point_t;
+
+
+int ljv7_unpack_profile_data(unsigned char* src, uint32_t src_sz, uint32_t num_pp, profile_point_t* dst, uint32_t dst_sz);
+
+
+#endif // __KEYENCE_DRIVER_LJV7_RAWDATA_H__

--- a/keyence_ljv_description/CMakeLists.txt
+++ b/keyence_ljv_description/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(keyence_ljv_description)
+
+find_package(catkin REQUIRED)
+
+catkin_package()
+
+foreach(dir config launch urdf)
+  install(
+    DIRECTORY ${dir}
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+endforeach()

--- a/keyence_ljv_description/config/rviz.rviz
+++ b/keyence_ljv_description/config/rviz.rviz
@@ -1,0 +1,191 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1
+      Splitter Ratio: 0.5
+    Tree Height: 650
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        sensor_aperture_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        sensor_optical_frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.01
+      Style: Points
+      Topic: /profiles
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        base_link:
+          Value: true
+        sensor_aperture_frame:
+          Value: true
+        sensor_optical_frame:
+          Value: true
+      Marker Scale: 0.5
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: false
+      Tree:
+        base_link:
+          sensor_aperture_frame:
+            sensor_optical_frame:
+              {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 0.965423
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.00919187
+        Y: -0.0112046
+        Z: -0.107541
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.430399
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.665399
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 888
+  Hide Left Dock: false
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd00000004000000000000013c0000031bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003f0000031b000000bb00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002adfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003f000002ad000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650000000000000004b00000021a00fffffffb0000000800540069006d00650100000000000004500000000000000000000003d80000031b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: true
+  Width: 1306
+  X: 158
+  Y: 21

--- a/keyence_ljv_description/launch/load_lj_v7080.launch
+++ b/keyence_ljv_description/launch/load_lj_v7080.launch
@@ -1,0 +1,3 @@
+<launch>
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find keyence_ljv_description)/urdf/lj_v7080.xacro'" />
+</launch>

--- a/keyence_ljv_description/launch/test_lj_v7080.launch
+++ b/keyence_ljv_description/launch/test_lj_v7080.launch
@@ -1,0 +1,8 @@
+<launch>
+  <include file="$(find keyence_ljv_description)/launch/load_lj_v7080.launch" />
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <param name="use_gui" value="false" />
+  </node>
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find keyence_ljv_description)/config/rviz.rviz" required="true" />
+</launch>

--- a/keyence_ljv_description/package.xml
+++ b/keyence_ljv_description/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package>
+  <name>keyence_ljv_description</name>
+  <version>0.1.0</version>
+  <description>URDFs for the Keyence LJ-V (7000) Ultra-High Speed In-Line Profilometers.</description>
+  <maintainer email="sedwards@swri.org">Shaun Edwards (Southwest Research Institute)</maintainer>
+  <license>BSD</license>
+
+  <url type="bugtracker">https://github.com/ros-industrial-consortium/godel/issues</url>
+  <url type="repository">https://github.com/ros-industrial-consortium/godel</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <run_depend>robot_state_publisher</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>rviz</run_depend>
+  <run_depend>xacro</run_depend>
+
+  <export>
+    <architecture_independent />
+  </export>
+</package>

--- a/keyence_ljv_description/urdf/lj_v7080.xacro
+++ b/keyence_ljv_description/urdf/lj_v7080.xacro
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<robot name="keyence_lj_v7080" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find keyence_ljv_description)/urdf/lj_v7080_macro.xacro"/>
+  <xacro:keyence_lj_v7080 prefix=""/>
+</robot>

--- a/keyence_ljv_description/urdf/lj_v7080_macro.xacro
+++ b/keyence_ljv_description/urdf/lj_v7080_macro.xacro
@@ -1,0 +1,49 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:property name="pi" value="3.1415926535897" />
+  <xacro:property name="box_l" value="0.096" />
+  <xacro:property name="box_h" value="0.071" />
+  <xacro:property name="box_w" value="0.042" />
+
+  <xacro:property name="ref_dist_a" value="0.080" />
+
+  <xacro:macro name="keyence_lj_v7080" params="prefix">
+    <link name="${prefix}base_link">
+      <visual>
+        <origin xyz="${box_l/-2} 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="${box_l} ${box_w} ${box_h}"/>
+        </geometry>
+        <material name="keyence_black">
+          <color rgba="0.15 0.15 0.15 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="${box_l/-2} 0 0" rpy="0 0 0"/>
+        <geometry>
+          <box size="${box_l} ${box_w} ${box_h}"/>
+        </geometry>
+      </collision>
+    </link>
+
+    <link name="${prefix}sensor_aperture_frame" />
+
+    <link name="${prefix}sensor_optical_frame" />
+
+    <!-- x, y, z still REP-103 -->
+    <joint name="${prefix}base_link-sensor_aperture_frame" type="fixed">
+      <origin xyz="-0.004 -0.003 -0.035" rpy="0 ${pi} 0" />
+      <parent link="${prefix}base_link" />
+      <child link="${prefix}sensor_aperture_frame" />
+    </joint>
+
+    <!-- Keyence: x+ left, y+ back, z+ up -->
+    <joint name="${prefix}sensor_aperture_frame-sensor_optical_frame" type="fixed">
+      <origin xyz="0 0 ${ref_dist_a}" rpy="0 ${-pi} ${pi/-2}" />
+      <parent link="${prefix}sensor_aperture_frame" />
+      <child link="${prefix}sensor_optical_frame" />
+    </joint>
+
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
as per subject.

This adds a driver node that interacts with a Keyence LJ-V 7000 series controller. See the `README.md` in the `godel_keyence_ljv_driver` package for more information on use and setup.

The `doc` attributes in the launch files will cause some warnings to be printed under Hydro, but I believe that they are preferable to xml comments.

Note that this has only been tested with a V7080 head, and is rather Godel project-specific.

This is not a complete driver and the code could use some major refactoring, but it is functional.
