### PR TITLE
polygon_offset: depend on new project specific OpenVoronoi wrapper pkg.

### DIFF
--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,0 +1,4 @@
+- git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git',
+    version: hydro-devel}
+- git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git',
+    version: hydro-devel}

--- a/godel_polygon_offset/CMakeLists.txt
+++ b/godel_polygon_offset/CMakeLists.txt
@@ -7,20 +7,12 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   cmake_modules
   godel_process_path_generation
+  godel_openvoronoi
 )
 
 find_package(Eigen REQUIRED)
 
-find_package(Boost REQUIRED COMPONENTS system python)
-
-# OpenVoronoi and dependencies
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-find_package(OpenVoronoi REQUIRED)
-
-# python devel libs needed because of OpenVoronoi python bindings?
-find_package(PythonLibs REQUIRED)
-list(APPEND OpenVoronoi_LIBRARIES ${PYTHON_LIBRARIES})
-list(APPEND OpenVoronoi_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
+find_package(Boost REQUIRED)
 
 ################################################
 ## Declare ROS messages, services and actions ##
@@ -40,9 +32,10 @@ generate_messages(DEPENDENCIES
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES godel_polygon_offset
-#  CATKIN_DEPENDS geometry_msgs roscpp
+  CATKIN_DEPENDS geometry_msgs roscpp message_runtime godel_process_path_generation godel_openvoronoi
 #  DEPENDS system_lib
 )
+
 
 ###########
 ## Build ##
@@ -50,7 +43,6 @@ catkin_package(
 
 include_directories(include
                     ${catkin_INCLUDE_DIRS}
-                    ${OpenVoronoi_INCLUDE_DIRS}
                     ${Eigen_INCLUDE_DIRS}
 )
 
@@ -60,7 +52,6 @@ add_library(godel_polygon_offset
 )
 target_link_libraries(godel_polygon_offset
                       ${catkin_LIBRARIES}
-                      ${OpenVoronoi_LIBRARIES}
                       ${Eigen_LIBRARIES}
                       ${Boost_LIBRARIES}
 )

--- a/godel_polygon_offset/README.md
+++ b/godel_polygon_offset/README.md
@@ -2,31 +2,3 @@ Godel Polygon Offset
 ==============
 
 This package offsets polygon boundaries for use in Godel blending.
-
-# Dependencies #
-**openvoronoi**
-
-Note: debian for openvoronoi is outdated, do not use.
-
-From source:
-
-- Install dependences
-  - cmake
-  - libqd-dev             http://crd.lbl.gov/~dhbailey/mpdist/
-  - Boost graph library
-
-- Download and build
-
-  - cd ~/Downloads
-  - git clone git://github.com/aewallin/openvoronoi.git
-  - cd openvoronoi
-  - mkdir bld
-  - cd bld
-  - cmake ../src
-  - make CFLAGS="-DNDEBUG"
-  - sudo make install
-
-After installation, patch offset_sorter.hpp
-
-- roscd godel_polygon_offset
-- sudo patch /usr/local/include/openvoronoi/offset_sorter.hpp < src/offset_sorter.patch

--- a/godel_polygon_offset/package.xml
+++ b/godel_polygon_offset/package.xml
@@ -11,14 +11,19 @@
 
   <!-- Build/run/test depends -->
   <buildtool_depend>catkin</buildtool_depend>
+
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>cmake_modules</build_depend>
   <build_depend>godel_process_path_generation</build_depend>
+  <build_depend>godel_openvoronoi</build_depend>
+
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>godel_process_path_generation</run_depend>
+  <run_depend>godel_openvoronoi</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
As per subject. This is for #33.

Note that this requires the fork of `openvoronoi` that can currently be found at [gavanderhoorn/godel_openvoronoi](https://github.com/gavanderhoorn/godel_openvoronoi). If this PR is accepted, that repository should be moved to the `ros-industrial-consortium` organisation.

The changes proposed in this PR do not require any updates to any of the other pkgs in the Godel repository.
