### PR TITLE
Fix for issue #51: add (some) missing run_depends to surface detection & moveit cfg.

### DIFF
--- a/godel_sia20d_moveit_config/package.xml
+++ b/godel_sia20d_moveit_config/package.xml
@@ -22,8 +22,7 @@
   <run_depend>xacro</run_depend>
   <build_depend>godel_robot_config</build_depend>
   <run_depend>godel_robot_config</run_depend>
-
+  <run_depend>motoman_sia20d_support</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
 </package>

--- a/godel_surface_detection/package.xml
+++ b/godel_surface_detection/package.xml
@@ -32,6 +32,7 @@
 	<run_depend>tf_conversions</run_depend>
 	<run_depend>godel_msgs</run_depend>
 	<run_depend>godel_process_path_generation</run_depend>
+	<run_depend>godel_sia20d_moveit_config</run_depend>
 
 
   <export>


### PR DESCRIPTION
As per subject.

A quick run with `catkin_lint` shows many more issues with pkg manifests & build scripts. I'll tackle those in a later PR.
