### PR TITLE
Parameter Helpers

### DIFF
--- a/godel_msgs/CMakeLists.txt
+++ b/godel_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
              sensor_msgs
              visualization_msgs
              trajectory_msgs
+             param_helpers
 )
 
 
@@ -52,7 +53,8 @@ generate_messages(DEPENDENCIES geometry_msgs sensor_msgs visualization_msgs traj
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs genmsg
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS message_runtime geometry_msgs sensor_msgs genmsg param_helpers
 )
 
 

--- a/godel_msgs/include/godel_msgs/blending_params_helper.h
+++ b/godel_msgs/include/godel_msgs/blending_params_helper.h
@@ -1,0 +1,50 @@
+#ifndef BLENDING_PARAMS_HELPER_H
+#define BLENDING_PARAMS_HELPER_H
+
+#include <param_helpers/param_interfaces.h>
+#include <godel_msgs/BlendingPlanParameters.h>
+
+namespace param_helpers 
+{
+
+template<>
+struct ParamInterfaces<godel_msgs::BlendingPlanParameters>
+{
+  template<typename Setter>
+  static void save(Setter& setter, const godel_msgs::BlendingPlanParameters& params)
+  {
+    setter.set("tool_radius", params.tool_radius);
+    setter.set("margin", params.margin);
+    setter.set("overlap", params.overlap);
+    setter.set("approach_spd", params.approach_spd);
+    setter.set("blending_spd", params.blending_spd);
+    setter.set("retract_spd", params.retract_spd);
+    setter.set("traverse_spd", params.traverse_spd);
+    setter.set("discretization", params.discretization);
+    setter.set("safe_traverse_height", params.safe_traverse_height);
+    setter.set("min_boundary_length", params.min_boundary_length);
+    setter.set("tool_force", params.tool_force);
+    setter.set("spindle_speed", params.spindle_speed);
+  }
+
+  template<typename Getter>
+  static void load(Getter& getter, godel_msgs::BlendingPlanParameters& params)
+  {
+    getter.get("tool_radius", params.tool_radius);
+    getter.get("margin", params.margin);
+    getter.get("overlap", params.overlap);
+    getter.get("approach_spd", params.approach_spd);
+    getter.get("blending_spd", params.blending_spd);
+    getter.get("retract_spd", params.retract_spd);
+    getter.get("traverse_spd", params.traverse_spd);
+    getter.get("discretization", params.discretization);
+    getter.get("safe_traverse_height", params.safe_traverse_height);
+    getter.get("min_boundary_length", params.min_boundary_length);
+    getter.get("tool_force", params.tool_force);
+    getter.get("spindle_speed", params.spindle_speed);
+  }
+};
+
+}
+
+#endif

--- a/godel_msgs/include/godel_msgs/robot_scan_params_helper.h
+++ b/godel_msgs/include/godel_msgs/robot_scan_params_helper.h
@@ -1,0 +1,103 @@
+#ifndef ROBOT_SCAN_PARAMS_HELPER_H
+#define ROBOT_SCAN_PARAMS_HELPER_H
+
+#include <param_helpers/param_interfaces.h>
+#include <godel_msgs/RobotScanParameters.h>
+
+namespace param_helpers 
+{
+
+template<>
+struct ParamInterfaces<godel_msgs::RobotScanParameters>
+{
+  template<typename Setter>
+  static void save(Setter& setter, const godel_msgs::RobotScanParameters& params)
+  {
+    setter.set("group_name", params.group_name);
+    setter.set("home_position", params.home_position);
+    setter.set("world_frame", params.world_frame);
+    setter.set("tcp_frame", params.tcp_frame);
+
+    setter.set("cam_to_obj_zoffset", params.cam_to_obj_zoffset);
+    setter.set("cam_to_obj_xoffset", params.cam_to_obj_xoffset);
+    setter.set("cam_tilt_angle", params.cam_tilt_angle);
+
+    setter.set("sweep_angle_start", params.sweep_angle_start);
+    setter.set("sweep_angle_end", params.sweep_angle_end);
+
+    setter.set("num_scan_points", params.num_scan_points);
+    setter.set("reachable_scan_points_ratio", params.reachable_scan_points_ratio);
+    bool b = params.stop_on_planning_error;
+    setter.set("stop_on_planning_error", b);
+
+    setter.set("scan_topic", params.scan_topic);
+    setter.set("scan_target_frame", params.scan_target_frame);
+
+    // Now we must generate the more complicated pose objects
+    setter.set("tcp_to_cam_pose/trans/x", params.tcp_to_cam_pose.position.x);
+    setter.set("tcp_to_cam_pose/trans/y", params.tcp_to_cam_pose.position.y);
+    setter.set("tcp_to_cam_pose/trans/z", params.tcp_to_cam_pose.position.z);
+    
+    setter.set("tcp_to_cam_pose/quat/x", params.tcp_to_cam_pose.orientation.x);
+    setter.set("tcp_to_cam_pose/quat/y", params.tcp_to_cam_pose.orientation.y);
+    setter.set("tcp_to_cam_pose/quat/z", params.tcp_to_cam_pose.orientation.z);
+    setter.set("tcp_to_cam_pose/quat/w", params.tcp_to_cam_pose.orientation.w);
+
+    setter.set("world_to_obj_pose/trans/x", params.world_to_obj_pose.position.x);
+    setter.set("world_to_obj_pose/trans/y", params.world_to_obj_pose.position.y);
+    setter.set("world_to_obj_pose/trans/z", params.world_to_obj_pose.position.z);
+    
+    setter.set("world_to_obj_pose/quat/x", params.world_to_obj_pose.orientation.x);
+    setter.set("world_to_obj_pose/quat/y", params.world_to_obj_pose.orientation.y);
+    setter.set("world_to_obj_pose/quat/z", params.world_to_obj_pose.orientation.z);
+    setter.set("world_to_obj_pose/quat/w", params.world_to_obj_pose.orientation.w);
+  }
+
+  template<typename Getter>
+  static void load(Getter& getter, godel_msgs::RobotScanParameters& params)
+  {
+    getter.get("group_name", params.group_name);
+    getter.get("home_position", params.home_position);
+    getter.get("world_frame", params.world_frame);
+    getter.get("tcp_frame", params.tcp_frame);
+
+    getter.get("cam_to_obj_zoffset", params.cam_to_obj_zoffset);
+    getter.get("cam_to_obj_xoffset", params.cam_to_obj_xoffset);
+    getter.get("cam_tilt_angle", params.cam_tilt_angle);
+
+    getter.get("sweep_angle_start", params.sweep_angle_start);
+    getter.get("sweep_angle_end", params.sweep_angle_end);
+
+    getter.get("num_scan_points", params.num_scan_points);
+    getter.get("reachable_scan_points_ratio", params.reachable_scan_points_ratio);
+    bool b;
+    getter.get("stop_on_planning_error", b);
+    params.stop_on_planning_error = b;
+
+    getter.get("scan_topic", params.scan_topic);
+    getter.get("scan_target_frame", params.scan_target_frame);
+
+    // Now we must generate the more complicated pose objects
+    getter.get("tcp_to_cam_pose/trans/x", params.tcp_to_cam_pose.position.x);
+    getter.get("tcp_to_cam_pose/trans/y", params.tcp_to_cam_pose.position.y);
+    getter.get("tcp_to_cam_pose/trans/z", params.tcp_to_cam_pose.position.z);
+    
+    getter.get("tcp_to_cam_pose/quat/x", params.tcp_to_cam_pose.orientation.x);
+    getter.get("tcp_to_cam_pose/quat/y", params.tcp_to_cam_pose.orientation.y);
+    getter.get("tcp_to_cam_pose/quat/z", params.tcp_to_cam_pose.orientation.z);
+    getter.get("tcp_to_cam_pose/quat/w", params.tcp_to_cam_pose.orientation.w);
+
+    getter.get("world_to_obj_pose/trans/x", params.world_to_obj_pose.position.x);
+    getter.get("world_to_obj_pose/trans/y", params.world_to_obj_pose.position.y);
+    getter.get("world_to_obj_pose/trans/z", params.world_to_obj_pose.position.z);
+    
+    getter.get("world_to_obj_pose/quat/x", params.world_to_obj_pose.orientation.x);
+    getter.get("world_to_obj_pose/quat/y", params.world_to_obj_pose.orientation.y);
+    getter.get("world_to_obj_pose/quat/z", params.world_to_obj_pose.orientation.z);
+    getter.get("world_to_obj_pose/quat/w", params.world_to_obj_pose.orientation.w);
+  }
+};
+
+}
+
+#endif

--- a/godel_msgs/include/godel_msgs/scan_params_helper.h
+++ b/godel_msgs/include/godel_msgs/scan_params_helper.h
@@ -1,0 +1,44 @@
+#ifndef SCAN_PARAMS_HELPER_H
+#define SCAN_PARAMS_HELPER_H
+
+#include <param_helpers/param_interfaces.h>
+#include <godel_msgs/ScanPlanParameters.h>
+
+namespace param_helpers 
+{
+
+template<>
+struct ParamInterfaces<godel_msgs::ScanPlanParameters>
+{
+  template<typename Setter>
+  static void save(Setter& setter, const godel_msgs::ScanPlanParameters& params)
+  {
+    setter.set("scan_width", params.scan_width);
+    setter.set("margin", params.margin);
+    setter.set("overlap", params.overlap);
+    setter.set("approach_distance", params.approach_distance);
+    setter.set("traverse_spd", params.traverse_spd);
+    setter.set("quality_metric", params.quality_metric);
+    setter.set("window_width", params.window_width);
+    setter.set("min_qa_value", params.min_qa_value);
+    setter.set("max_qa_value", params.max_qa_value);
+  }
+
+  template<typename Getter>
+  static void load(Getter& getter, godel_msgs::ScanPlanParameters& params)
+  {
+    getter.get("scan_width", params.scan_width);
+    getter.get("margin", params.margin);
+    getter.get("overlap", params.overlap);
+    getter.get("approach_distance", params.approach_distance);
+    getter.get("traverse_spd", params.traverse_spd);
+    getter.get("quality_metric", params.quality_metric);
+    getter.get("window_width", params.window_width);
+    getter.get("min_qa_value", params.min_qa_value);
+    getter.get("max_qa_value", params.max_qa_value);
+  }
+};
+
+}
+
+#endif

--- a/godel_msgs/include/godel_msgs/surface_detection_params_helper.h
+++ b/godel_msgs/include/godel_msgs/surface_detection_params_helper.h
@@ -1,0 +1,128 @@
+#ifndef SURFACE_DETECTION_PARAMS_HELPER
+#define SURFACE_DETECTION_PARAMS_HELPER
+
+#include <param_helpers/param_interfaces.h>
+#include <godel_msgs/SurfaceDetectionParameters.h>
+
+namespace param_helpers 
+{
+
+template<>
+struct ParamInterfaces<godel_msgs::SurfaceDetectionParameters>
+{
+  template<typename Setter>
+  static void save(Setter& setter, const godel_msgs::SurfaceDetectionParameters& params)
+  {
+    //  acquisition
+    setter.set("frame_id", params.frame_id);
+
+    //  filter and normal estimation
+    setter.set("meanK", params.meanK);
+    setter.set("k_search", params.k_search);
+    setter.set("stdv_threshold", params.stdv_threshold);
+
+    //  region growing
+    setter.set("rg_min_cluster_size", params.rg_min_cluster_size);
+    setter.set("rg_max_cluster_size", params.rg_max_cluster_size);
+    setter.set("rg_neightbors", params.rg_neightbors);
+    setter.set("rg_smoothness_threshold", params.rg_smoothness_threshold);
+    setter.set("rg_curvature_threshold", params.rg_curvature_threshold);
+
+    //  fast triangulation
+    setter.set("tr_search_radius", params.tr_search_radius);
+    setter.set("tr_mu", params.tr_mu);
+    setter.set("tr_max_nearest_neighbors", params.tr_max_nearest_neighbors);
+    setter.set("tr_max_surface_angle", params.tr_max_surface_angle);
+    setter.set("tr_min_angle", params.tr_min_angle);
+    setter.set("tr_max_angle", params.tr_max_angle);
+    bool b0 = params.tr_normal_consistency; setter.set("tr_normal_consistency", b0);
+
+    //  plane approximation refinement: Assumes planar surfaces in order to identify additional inlier points
+    bool b1 = params.pa_enabled; setter.set("pa_enabled", b1);
+    setter.set("pa_seg_max_iterations", params.pa_seg_max_iterations);
+    setter.set("pa_seg_dist_threshold", params.pa_seg_dist_threshold);
+    setter.set("pa_sac_plane_distance", params.pa_sac_plane_distance);
+    setter.set("pa_kdtree_radius", params.pa_kdtree_radius);
+
+    //  voxel downsampling
+    setter.set("voxel_leafsize", params.voxel_leafsize);
+
+    //  octomap occupancy
+    bool b2 = params.use_octomap; setter.set("use_octomap", b2);
+    setter.set("occupancy_threshold", params.occupancy_threshold);
+
+    //  moving least square smoothing
+    setter.set("mls_upsampling_radius", params.mls_upsampling_radius);
+    setter.set("mls_search_radius", params.mls_search_radius);
+    setter.set("mls_point_density", params.mls_point_density);
+
+    //  tabletop segmentation
+    bool b3 = params.use_tabletop_seg; setter.set("use_tabletop_seg", b3);
+    setter.set("tabletop_seg_distance_threshold", params.tabletop_seg_distance_threshold);
+
+    //  options
+    setter.set("marker_alpha", params.marker_alpha);
+    bool b4 = params.ignore_largest_cluster; setter.set("ignore_largest_cluster", b4);
+  }
+
+  template<typename Getter>
+  static void load(Getter& getter, godel_msgs::SurfaceDetectionParameters& params)
+  {
+    //  acquisition
+    getter.get("frame_id", params.frame_id);
+
+    //  filter and normal estimation
+    getter.get("meanK", params.meanK);
+    getter.get("k_search", params.k_search);
+    getter.get("stdv_threshold", params.stdv_threshold);
+
+    //  region growing
+    getter.get("rg_min_cluster_size", params.rg_min_cluster_size);
+    getter.get("rg_max_cluster_size", params.rg_max_cluster_size);
+    getter.get("rg_neightbors", params.rg_neightbors);
+    getter.get("rg_smoothness_threshold", params.rg_smoothness_threshold);
+    getter.get("rg_curvature_threshold", params.rg_curvature_threshold);
+
+    //  fast triangulation
+    getter.get("tr_search_radius", params.tr_search_radius);
+    getter.get("tr_mu", params.tr_mu);
+    getter.get("tr_max_nearest_neighbors", params.tr_max_nearest_neighbors);
+    getter.get("tr_max_surface_angle", params.tr_max_surface_angle);
+    getter.get("tr_min_angle", params.tr_min_angle);
+    getter.get("tr_max_angle", params.tr_max_angle);
+    bool b0; getter.get("tr_normal_consistency", b0); params.tr_normal_consistency = b0;
+
+    //  plane approximation refinement: Assumes planar surfaces in order to identify additional inlier points
+    bool b1; getter.get("pa_enabled", b1); params.pa_enabled = b1;
+    getter.get("pa_seg_max_iterations", params.pa_seg_max_iterations);
+    getter.get("pa_seg_dist_threshold", params.pa_seg_dist_threshold);
+    getter.get("pa_sac_plane_distance", params.pa_sac_plane_distance);
+    getter.get("pa_kdtree_radius", params.pa_kdtree_radius);
+
+    //  voxel downsampling
+    getter.get("voxel_leafsize", params.voxel_leafsize);
+
+    //  octomap occupancy
+    bool b2; getter.get("use_octomap", b2); params.use_octomap = b2;
+    getter.get("occupancy_threshold", params.occupancy_threshold);
+
+    //  moving least square smoothing
+    getter.get("mls_upsampling_radius", params.mls_upsampling_radius);
+    getter.get("mls_search_radius", params.mls_search_radius);
+    getter.get("mls_point_density", params.mls_point_density);
+
+    //  tabletop segmentation
+    bool b3; getter.get("use_tabletop_seg", b3); params.use_tabletop_seg = b3;
+    getter.get("tabletop_seg_distance_threshold", params.tabletop_seg_distance_threshold);
+
+    //  options
+    getter.get("marker_alpha", params.marker_alpha);
+    bool b4; getter.get("ignore_largest_cluster", b4); params.ignore_largest_cluster = b4;
+  }
+};
+
+
+
+}
+
+#endif

--- a/godel_msgs/package.xml
+++ b/godel_msgs/package.xml
@@ -15,6 +15,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
+  <build_depend>param_helpers</build_depend>
   
   <run_depend>genmsg</run_depend>
   <run_depend>geometry_msgs</run_depend>
@@ -22,6 +23,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>trajectory_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
+  <run_depend>param_helpers</run_depend>
 
 
   <export>

--- a/param_helpers/CMakeLists.txt
+++ b/param_helpers/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(param_helpers)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+)
+
+catkin_package(
+ INCLUDE_DIRS include
+ CATKIN_DEPENDS roscpp
+ DEPENDS yaml-cpp
+)
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)

--- a/param_helpers/include/param_helpers/param_interfaces.h
+++ b/param_helpers/include/param_helpers/param_interfaces.h
@@ -1,0 +1,12 @@
+#ifndef PARAM_INTERFACES
+#define PARAM_INTERFACES
+
+namespace param_helpers
+{
+
+template<typename T>
+struct ParamInterfaces;
+
+}
+
+#endif

--- a/param_helpers/include/param_helpers/param_set.h
+++ b/param_helpers/include/param_helpers/param_set.h
@@ -1,0 +1,57 @@
+#ifndef PARAM_SET_H
+#define PARAM_SET_H
+
+#include <param_helpers/param_interfaces.h>
+#include <param_helpers/yaml_interface.h>
+#include <param_helpers/rosparam_interface.h>
+
+#include <fstream>
+
+namespace param_helpers
+{
+  template<typename Data>
+  inline void readFromParamServer(Data& data, const std::string& ns = "")
+  {
+    RosParamReaderWriter param_server(ns);
+    ParamInterfaces<Data>::load(param_server, data);
+  }
+
+  template<typename Data>
+  inline void saveToYamlFile(const Data& data, const std::string& file, const std::string& ns = "")
+  {
+    YamlFileWriter yaml_file (file, ns);
+    ParamInterfaces<Data>::save(yaml_file, data);
+  }
+
+  template<typename Data>
+  inline void readFromYamlFile(Data& data, const std::string& file, const std::string& ns = "")
+  {
+    YamlFileReader yaml_file (file, ns);
+    ParamInterfaces<Data>::load(yaml_file, data);
+  }
+
+  inline bool checkForYamlFile(const std::string& file)
+  {
+    std::ifstream f (file.c_str());
+    if (f.good()) return true;
+    else return false;
+  }
+
+  template<typename Data>
+  inline void attemptCacheLoad(Data& data, const std::string& file_name, const std::string& ns = "")
+  {
+    ROS_INFO_STREAM("Attempting to load parameters from file  " << file_name << " with ns " << ns);
+    if (checkForYamlFile(file_name))
+    {
+      readFromYamlFile(data, file_name, ns);
+    }
+    else
+    {
+      ROS_INFO_STREAM("Defaulting to parameter server");
+      readFromParamServer(data, "~/" + ns);
+    }
+  }
+
+}
+
+#endif

--- a/param_helpers/include/param_helpers/rosparam_interface.h
+++ b/param_helpers/include/param_helpers/rosparam_interface.h
@@ -1,0 +1,40 @@
+#ifndef ROSPARAM_INTERFACE_H
+#define ROSPARAM_INTERFACE_H
+
+#include <ros/ros.h>
+
+namespace param_helpers
+{
+
+class RosParamReaderWriter
+{
+public:
+  RosParamReaderWriter(const std::string& ns)
+    : nh_(ns)
+  {}
+
+  template<class T>
+  void set(const std::string& key, const T& value)
+  {
+    nh_.setParam(key, value);
+  }
+
+  template<class T>
+  void get(const std::string& key, T& value)
+  {
+    if (!(nh_.getParam(key, value)))
+    {
+      std::ostringstream os;
+      os << "Could not load param " << key << " from server";
+      throw std::runtime_error(os.str());
+    }
+      
+  }
+
+private:
+  ros::NodeHandle nh_;
+};
+
+}
+
+#endif

--- a/param_helpers/include/param_helpers/yaml_interface.h
+++ b/param_helpers/include/param_helpers/yaml_interface.h
@@ -1,0 +1,87 @@
+#ifndef YAML_INTERFACE_H
+#define YAML_INTERFACE_H
+
+#include <yaml-cpp/yaml.h>
+#include <fstream>
+
+namespace param_helpers
+{
+
+inline
+std::vector<std::string> splitString(const std::string& s, char delim, const std::string& prefix = "")
+{
+  std::istringstream ss(s);
+  std::string token;
+  std::vector<std::string> tokens;
+  if (!prefix.empty()) tokens.push_back(prefix);
+  while (std::getline(ss, token, delim))
+  {
+    if (!token.empty()) tokens.push_back(token);
+  }
+  return tokens;
+}
+
+inline
+YAML::Node getNode(YAML::Node n, const std::vector<std::string>& tokens)
+{
+  for (unsigned i = 0; i < tokens.size(); ++i) n.reset(n[tokens[i]]);
+  return n;
+}
+
+class YamlFileReader
+{
+public:
+  YamlFileReader(const std::string& filename, const std::string prefix = "")
+    : filename_(filename)
+    , prefix_(prefix)
+    , node_(YAML::LoadFile(filename))
+    {}
+
+  template<class T>
+  void get(const std::string& key, T& value)
+  {
+    std::vector<std::string> tokens = splitString(key, '/', prefix_);
+    YAML::Node n = getNode(node_, tokens);
+    value = n.as<T>();
+  }
+
+  private:
+    std::string filename_, prefix_;
+    YAML::Node node_;
+};
+
+class YamlFileWriter
+{
+public:
+  YamlFileWriter(const std::string& filename, const std::string prefix = "")
+    : filename_(filename)
+    , prefix_(prefix)
+    , node_(YAML::NodeType::Map)
+    {
+    }
+
+  template<class T>
+  void set(const std::string& key, const T& value)
+  {
+    std::vector<std::string> tokens = splitString(key, '/', prefix_);
+    YAML::Node n = getNode(node_, tokens);
+    n = value;
+  }
+
+   ~YamlFileWriter()
+  {
+    std::ofstream ofile (filename_.c_str());
+    if (!ofile) ROS_ERROR_STREAM("Could not save parameters on exit");
+    ofile << node_;
+  }
+
+private:
+  std::string filename_, prefix_;
+  YAML::Node node_;
+};
+
+
+
+}
+
+#endif

--- a/param_helpers/package.xml
+++ b/param_helpers/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package>
+  <name>param_helpers</name>
+  <version>0.1.0</version>
+  <description>
+    Header-only utility library for loading/saving parameter messages to
+    different interfaces such as the ROS Param Server and a YAML file with
+    a uniform syntax. 
+  </description>
+
+  <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
+
+  <license>Apache2</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <run_depend>roscpp</run_depend>
+</package>


### PR DESCRIPTION
The Godel project's working status has grown so far beyond the head of this directory that it's not really feasible or worthwhile to iterate through the commits in the order they were added.

This PR represents the first of a new approach where I will begin adding peripheral components, updates to specific files, and eventually core changes that will bring the repo up to the working status. 

This specific PR adds a set of helper functions for caching parameter messages to the user's filesystem via YAML files with the ability to fall back onto the parameter server. This includes implementations for all four of the major message components.

This PR does not contain the usage of these helpers. That will come in the very next PR.
