### PR TITLE
Missing Return Statement

### DIFF
--- a/godel_surface_detection/src/detection/surface_detection.cpp
+++ b/godel_surface_detection/src/detection/surface_detection.cpp
@@ -831,6 +831,7 @@ bool SurfaceDetection::apply_planar_reprojection(const Cloud& in, Cloud& out)
 	proj.setInputCloud (out.makeShared());
 	proj.setModelCoefficients(coeff_ptr);
 	proj.filter (out);
+	return true;
 }
 
 bool SurfaceDetection::apply_concave_hull(const Cloud& in, pcl::PolygonMesh& mesh)


### PR DESCRIPTION
Addresses #55. A function that should return true did not have a return statement, and defaults to false on many platforms. 
