### PR TITLE
Trajectory Planner Crashes

### DIFF
--- a/motoman_sia20d_descartes/include/motoman_sia20d_descartes/motoman_sia20d_robot_model.h
+++ b/motoman_sia20d_descartes/include/motoman_sia20d_descartes/motoman_sia20d_robot_model.h
@@ -29,7 +29,7 @@ namespace motoman_sia20d_descartes
 
     MotomanSia20dRobotModel();
 
-    virtual bool initialize(const std::string robot_description, const std::string& group_name,
+    virtual bool initialize(const std::string& robot_description, const std::string& group_name,
                         const std::string& world_frame,const std::string& tcp_frame);
 
     virtual bool getAllIK(const Eigen::Affine3d &pose, std::vector<std::vector<double> > &joint_poses) const;

--- a/motoman_sia20d_descartes/src/motoman_sia20d_robot_model.cpp
+++ b/motoman_sia20d_descartes/src/motoman_sia20d_robot_model.cpp
@@ -34,7 +34,7 @@ namespace motoman_sia20d_descartes
 
   }
 
-  bool MotomanSia20dRobotModel::initialize(const std::string robot_description, const std::string& group_name,
+  bool MotomanSia20dRobotModel::initialize(const std::string& robot_description, const std::string& group_name,
                                     const std::string& world_frame,const std::string& tcp_frame)
   {
     MoveitStateAdapter::initialize(robot_description,group_name,world_frame,tcp_frame);


### PR DESCRIPTION
This PR is made with the same intent of #65: to return the system to a working state.

Once upon a time we changed the Descartes Robot Model's initialize function to take all arguments by constant reference. This change was not reflected in the robot model, so it causes a crash when first invoked. This PR fixes that.
