### PR TITLE
Process Planning Services

### DIFF
--- a/godel_process_planning/CMakeLists.txt
+++ b/godel_process_planning/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(godel_process_planning)
+
+find_package(catkin REQUIRED COMPONENTS
+  descartes_core
+  descartes_moveit
+  descartes_planner
+  descartes_trajectory
+  godel_msgs
+  moveit_ros_planning_interface
+  roscpp
+)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS
+    descartes_core
+    descartes_moveit
+    descartes_planner
+    descartes_trajectory
+    godel_msgs 
+    moveit_ros_planning_interface 
+    roscpp
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp executable
+add_executable(godel_process_planning_node 
+  src/blend_process_planning.cpp
+  src/common_utils.cpp
+  src/godel_process_planning.cpp
+  src/godel_process_planning_node.cpp
+  src/keyence_process_planning.cpp
+  src/trajectory_utils.cpp
+)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+add_dependencies(godel_process_planning_node godel_msgs_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(godel_process_planning_node
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# Mark executables and/or libraries for installation
+install(TARGETS godel_process_planning_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/godel_process_planning/include/godel_process_planning/godel_process_planning.h
+++ b/godel_process_planning/include/godel_process_planning/godel_process_planning.h
@@ -1,0 +1,51 @@
+#ifndef GODEL_PROCESS_PLANNING_H
+#define GODEL_PROCESS_PLANNING_H
+
+#include "godel_msgs/BlendProcessPlanning.h"
+#include "godel_msgs/KeyenceProcessPlanning.h"
+
+#include <descartes_core/robot_model.h>
+#include <pluginlib/class_loader.h>
+
+/*
+ * This class wraps Descartes planning methods and provides functionality for configuration
+ * and for planning for blending/scanning paths.
+ *
+ * The general plannning approach is:
+ *
+ * 1. Find the closest starting point for robot between where it is now and the first point
+ *    in the trajectory.
+ * 2. Create a linear-joint motion to the start point, append the path, and add a linear
+ *    path home
+ * 3. Make a rough plan that moves through these points and solve
+ * 4. Replan for the approach and departure using this plan as a 'seed'. Only at this point
+ *    are collisions considered.
+ */
+namespace godel_process_planning
+{
+
+class ProcessPlanningManager
+{
+public:
+  ProcessPlanningManager(const std::string& world_frame, const std::string& blend_group,
+                         const std::string& blend_tcp, const std::string& keyence_group,
+                         const std::string& keyence_tcp, const std::string& robot_model_plugin);
+
+  bool handleBlendPlanning(godel_msgs::BlendProcessPlanning::Request& req,
+                           godel_msgs::BlendProcessPlanning::Response& res);
+
+  bool handleKeyencePlanning(godel_msgs::KeyenceProcessPlanning::Request& req,
+                             godel_msgs::KeyenceProcessPlanning::Response& res);
+
+private:
+  descartes_core::RobotModelPtr blend_model_;
+  descartes_core::RobotModelPtr keyence_model_;
+  moveit::core::RobotModelConstPtr moveit_model_;
+  pluginlib::ClassLoader<descartes_core::RobotModel> plugin_loader_; // kept around so code doesn't get unloaded
+  std::string blend_group_name_;
+  std::string keyence_group_name_;
+};
+
+}
+
+#endif

--- a/godel_process_planning/launch/process_planning.launch
+++ b/godel_process_planning/launch/process_planning.launch
@@ -1,0 +1,17 @@
+<launch>
+  <arg name="world_frame" default="world_frame"/>
+  <arg name="blend_group" default="manipulator_tcp"/>
+  <arg name="blend_tcp" default="tcp_frame"/>
+  <arg name="keyence_group" default="manipulator_keyence"/>
+  <arg name="keyence_tcp" default="keyence_tcp_frame"/>
+  <arg name="robot_model_plugin"/>
+
+  <node name="godel_process_planning" pkg="godel_process_planning" type="godel_process_planning_node">
+    <param name="world_frame" value="$(arg world_frame)"/>
+    <param name="blend_group" value="$(arg blend_group)"/>
+    <param name="blend_tcp" value="$(arg blend_tcp)"/>
+    <param name="keyence_group" value="$(arg keyence_group)"/>
+    <param name="keyence_tcp" value="$(arg keyence_tcp)"/>
+    <param name="robot_model_plugin" value="$(arg robot_model_plugin)"/>
+  </node>
+</launch>

--- a/godel_process_planning/package.xml
+++ b/godel_process_planning/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package>
+  <name>godel_process_planning</name>
+  <version>0.1.0</version>
+  <description>
+    The process planning package handles joint trajectory planning for (at the
+    moment) two distinct processes: blending and laser line scanning. This package replaces the earlier 'godel_path_planning'.
+  </description>
+
+  <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
+  <author email="jmeyer@swri.org">Jonathan Meyer</author>
+  
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>descartes_core</build_depend>
+  <build_depend>descartes_moveit</build_depend>
+  <build_depend>descartes_planner</build_depend>
+  <build_depend>descartes_trajectory</build_depend>
+  <build_depend>godel_msgs</build_depend>
+  <build_depend>moveit_ros_planning_interface</build_depend>
+  <build_depend>roscpp</build_depend>
+
+  <run_depend>descartes_core</run_depend>
+  <run_depend>descartes_moveit</run_depend>
+  <run_depend>descartes_planner</run_depend>
+  <run_depend>descartes_trajectory</run_depend>
+  <run_depend>godel_msgs</run_depend>
+  <run_depend>moveit_ros_planning_interface</run_depend>
+  <run_depend>roscpp</run_depend>
+
+</package>

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -1,0 +1,209 @@
+#include <godel_process_planning/godel_process_planning.h>
+
+#include <ros/console.h>
+
+// descartes
+#include "descartes_trajectory/axial_symmetric_pt.h"
+#include "descartes_trajectory/joint_trajectory_pt.h"
+#include "descartes_planner/dense_planner.h"
+
+#include "common_utils.h"
+#include "boost/make_shared.hpp"
+
+
+namespace godel_process_planning
+{
+
+// Planning Constants
+const double BLENDING_ANGLE_DISCRETIZATION = M_PI / 12.0; // The discretization of the tool's pose about
+                                                          // the z axis
+const double FREE_SPACE_MAX_ANGLE_DELTA = M_PI_2; // The maximum angle a joint during a freespace motion
+                                                  // from the start to end position without that motion
+                                                  // being penalized. Avoids flips.
+const double FREE_SPACE_ANGLE_PENALTY = 5.0; // The factor by which a joint motion is multiplied if said
+                                             // motion is greater than the max.
+const static std::string JOINT_TOPIC_NAME = "joint_states"; // ROS topic to subscribe to for current robot
+                                                            // state info
+
+/**
+ * @brief Translated an Eigen pose to a Descartes trajectory point appropriate for the BLEND process!
+ *        Note that this function is local only to this file, and there is a similar function in
+ *        the keyence_process_planning.cpp document.
+ * @param pose
+ * @param dt The upper limit of time from the previous point to achieve this one
+ * @return A descartes trajectory point encapsulating a move to this pose
+ */
+static inline descartes_core::TrajectoryPtPtr toDescartesPt(const Eigen::Affine3d& pose, double dt)
+{
+  using namespace descartes_trajectory;
+  using namespace descartes_core;
+  const TimingConstraint tm (dt);
+  return boost::make_shared<AxialSymmetricPt>(pose, BLENDING_ANGLE_DISCRETIZATION,
+                                              AxialSymmetricPt::Z_AXIS, tm);
+}
+
+/**
+ * @brief Computes a 'cost' value for a robot motion between 'source' and 'target'
+ * @param source  The joint configuration at start of motion
+ * @param target  The joint configuration at end of motion
+ * @return cost value
+ */
+static inline double freeSpaceCostFunction(const std::vector<double>& source,
+                                           const std::vector<double>& target)
+{
+  // The cost function here penalizes large single joint motions in an effort to
+  // keep the robot from flipping a joint, even if some other joints have to move
+  // a bit more.
+  double cost = 0.0;
+  for (std::size_t i = 0; i < source.size(); ++i)
+  {
+    double diff = std::abs(source[i] - target[i]);
+    if (diff > FREE_SPACE_MAX_ANGLE_DELTA)
+      cost += FREE_SPACE_ANGLE_PENALTY * diff;
+    else
+      cost += diff;
+  }
+  return cost;
+}
+
+/**
+ * @brief transforms an input, in the form of a reference pose and points relative to that pose, into Descartes'
+ *        native format. Also adds in associated parameters.
+ * @param ref The reference posed that all points are multiplied by. Should be in the world space of the blend move group.
+ * @param points Sequence of points (relative to ref and the world space of blending robot model)
+ * @param params Surface blending parameters, including info such as traversal speed
+ * @return The input trajectory encoded in Descartes points
+ */
+static godel_process_planning::DescartesTraj toDescartesTraj(const geometry_msgs::Pose& ref,
+                                                             const std::vector<geometry_msgs::Point>& points,
+                                                             const godel_msgs::BlendingPlanParameters& params)
+{
+  DescartesTraj traj;
+  traj.reserve(points.size());
+  if (points.empty()) return traj;
+
+  Eigen::Affine3d last_pose = createNominalTransform(ref, points.front());
+
+  for (std::size_t i = 0; i < points.size(); ++i)
+  {
+    Eigen::Affine3d this_pose = createNominalTransform(ref, points[i]);
+    // O(1) jerky - may need to revisit this time parameterization later. This at least allows
+    // Descartes to perform some optimizations in its graph serach.
+    double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
+    traj.push_back( toDescartesPt(this_pose, dt) );
+    last_pose = this_pose;
+  }
+
+  return traj;
+}
+
+/**
+ * @brief Computes a joint motion plan based on input points and the blending process; this includes
+ *        motion from current position to process path and back to the starting position.
+ * @param req Process plan including reference pose, points, and process parameters
+ * @param res Set of approach, process, and departure trajectories
+ * @return True if a valid plan was generated; false otherwise
+ */
+bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlanning::Request& req,
+                                                 godel_msgs::BlendProcessPlanning::Response& res)
+{
+  // Precondition: Input trajectory must be non-zero
+  if (req.path.points.empty())
+  {
+    ROS_WARN("%s: Cannot create blend process plan for empty trajectory",  __FUNCTION__);
+    return false;
+  }
+
+  // Transform process path from geometry msgs to descartes points
+  DescartesTraj process_points = toDescartesTraj(req.path.reference, req.path.points, req.params);
+
+  // Capture the current state of the robot
+  std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
+
+  // Compute all of the joint poses at the start of the process path
+  std::vector<std::vector<double> > start_joint_poses;
+  process_points.front()->getJointPoses(*blend_model_, start_joint_poses);
+
+  // Search for the 'best' config from available joint poses at start of
+  // process path, relative to our fixed starting position
+  size_t best_index = 0;
+  double best_cost = std::numeric_limits<double>::max();
+  ROS_DEBUG_STREAM("Possible starting poses: " << start_joint_poses.size());
+  for (size_t i = 0; i < start_joint_poses.size(); ++i)
+  {
+    double cost = freeSpaceCostFunction(start_joint_poses[i], current_joints);
+    if (cost < best_cost)
+    {
+      ROS_DEBUG_STREAM("New best cost: " << cost << " at " << i);
+      best_cost = cost;
+      best_index = i;
+    }
+  }
+
+  DescartesTraj solved_path;
+  // Calculate tool pose of robot starting config so that we can go back here on the
+  // return move
+  Eigen::Affine3d init_pose;
+  blend_model_->getFK(current_joints, init_pose);
+  // Compute the nominal tool pose of the final process point
+  Eigen::Affine3d process_stop_pose;
+  process_points.back()->getNominalCartPose(std::vector<double>(), *blend_model_, process_stop_pose);
+
+  // Joint interpolate from the initial robot position to 'best' starting configuration of process path
+  DescartesTraj to_process = createJointPath(current_joints, start_joint_poses[best_index]);
+  to_process.front() = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
+
+  // To get a rough estimate of process path cost, add a cartesian move from the final process point
+  // to the starting position again.
+  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
+  from_process.back() = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
+
+  // Affix the approach and depart paths calculated above with user process path
+  DescartesTraj seed_path;
+  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
+  seed_path.insert(seed_path.end(), process_points.begin(), process_points.end());
+  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
+
+  // Attempt to solve the initial path (minimize joint motion over entire plan)
+  if (!descartesSolve(seed_path, blend_model_, solved_path))
+  {
+    return false;
+  }
+
+  // Go back over and recalculate the approach and depart segments to:
+  //  1. Use a joint interpolation from start to stop if collision free
+  //  2. Use MoveIt (RRT-Connect) if the above fails
+  // This is the only portion of the trajectory that is collision checked. Note this
+  // method also converts the Descartes points into ROS trajectories.
+  trajectory_msgs::JointTrajectory approach = planFreeMove(*blend_model_, blend_group_name_, moveit_model_,
+                                                           extractJoints(*blend_model_, *solved_path[0]),
+                                                           extractJoints(*blend_model_, *solved_path[to_process.size()]));
+
+  trajectory_msgs::JointTrajectory depart = planFreeMove(*blend_model_, blend_group_name_, moveit_model_,
+                                                         extractJoints(*blend_model_, *solved_path[to_process.size() + process_points.size() -1]),
+                                                         extractJoints(*blend_model_, *solved_path[seed_path.size() - 1]));
+
+  // Break out the process path from the seed path and convert to ROS messages
+  DescartesTraj process_part (solved_path.begin() + to_process.size(), solved_path.end() - from_process.size());
+  trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *blend_model_);
+
+  // Fill in result trajectories
+  res.plan.trajectory_process = process;
+  res.plan.trajectory_approach = approach;
+  res.plan.trajectory_depart = depart;
+
+  // Fill in result header information
+  const std::vector< std::string >& joint_names =
+      moveit_model_->getJointModelGroup(blend_group_name_)->getActiveJointModelNames();
+
+  godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_approach);
+  godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_depart);
+  godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_process);
+
+  // set the type to blend plan
+  res.plan.type = godel_msgs::ProcessPlan::BLEND_TYPE;
+
+  return true;
+}
+
+}

--- a/godel_process_planning/src/common_utils.cpp
+++ b/godel_process_planning/src/common_utils.cpp
@@ -1,0 +1,260 @@
+#include "common_utils.h"
+#include <eigen_conversions/eigen_msg.h>
+#include <descartes_planner/dense_planner.h>
+#include <descartes_planner/sparse_planner.h>
+#include <descartes_trajectory/axial_symmetric_pt.h>
+
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit_msgs/GetMotionPlan.h>
+
+#include <ros/topic.h>
+#include "trajectory_utils.h"
+
+// Constants
+const static double DEFAULT_TIME_UNDEFINED_VELOCITY = 0.1;  // When a Descartes trajectory point has no timing info associated
+                                                            // with it, this value (in seconds) is used instead
+const static std::string DEFAULT_FRAME_ID = "world_frame";  // The default frame_id used for trajectories generated
+                                                            // by these helper functions
+const static double DEFAULT_ANGLE_DISCRETIZATION = M_PI / 12.0;   // Default discretization used for axially-symmetric points
+                                                                  // in these helper functions
+const static double DEFAULT_JOINT_WAIT_TIME = 5.0;          // Maximum time allowed to capture a new joint
+                                                            // state message
+
+// MoveIt Configuration Constants
+const static int DEFAULT_MOVEIT_NUM_PLANNING_ATTEMPTS = 20;
+const static double DEFAULT_MOVEIT_PLANNING_TIME = 20.0;    // seconds
+const static double DEFAULT_MOVEIT_VELOCITY_SCALING = 0.1;  // Slow down the robot
+const static std::string DEFAULT_MOVEIT_PLANNER_ID = "RRTConnectkConfigDefault";
+const static std::string DEFAULT_MOVEIT_FRAME_ID = "world_frame";
+const static std::string DEFAULT_MOVEIT_PLANNING_SERVICE_NAME = "plan_kinematic_path";
+
+Eigen::Affine3d godel_process_planning::createNominalTransform(const geometry_msgs::Pose& ref_pose,
+                                                               const geometry_msgs::Point& pt)
+{
+  Eigen::Affine3d eigen_pose;
+  Eigen::Vector3d eigen_pt;
+
+  tf::poseMsgToEigen(ref_pose, eigen_pose);
+  tf::pointMsgToEigen(pt, eigen_pt);
+
+  // Translation transform
+  Eigen::Affine3d to_point;
+  to_point = Eigen::Translation3d(eigen_pt);
+
+  // Reverse the Z axis
+  Eigen::Affine3d flip_z;
+  flip_z = Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitY());
+
+  return eigen_pose * to_point * flip_z;
+}
+
+bool godel_process_planning::descartesSolve(const godel_process_planning::DescartesTraj& in_path,
+                                            descartes_core::RobotModelConstPtr robot_model,
+                                            godel_process_planning::DescartesTraj& out_path)
+{
+  // Create planner
+  descartes_core::PathPlannerBasePtr planner (new descartes_planner::DensePlanner);
+  if (!planner->initialize(robot_model))
+  {
+    ROS_ERROR("%s: Failed to initialize planner with robot model", __FUNCTION__);
+    return false;
+  }
+
+  if (!planner->planPath(in_path))
+  {
+    ROS_ERROR("%s: Failed to plan for given trajectory.", __FUNCTION__);
+    return false;
+  }
+
+  if (!planner->getPath(out_path))
+  {
+    ROS_ERROR("%s: Failed to retrieve path.", __FUNCTION__);
+    return false;
+  }
+
+  return true;
+}
+
+trajectory_msgs::JointTrajectory
+godel_process_planning::toROSTrajectory(const godel_process_planning::DescartesTraj& solution,
+                                        const descartes_core::RobotModel& model)
+{
+  ros::Duration from_start(0.0);
+  std::vector<double> joint_point;
+  std::vector<double> dummy;
+  trajectory_msgs::JointTrajectory ros_trajectory; // result
+
+  for (std::size_t i = 0; i < solution.size(); ++i)
+  {
+    solution[i]->getNominalJointPose(dummy, model, joint_point);
+
+    trajectory_msgs::JointTrajectoryPoint pt;
+    pt.positions = joint_point;
+    pt.velocities.resize(joint_point.size(), 0.0);
+    pt.accelerations.resize(joint_point.size(), 0.0);
+    pt.effort.resize(joint_point.size(), 0.0);
+
+    double time_step = solution[i]->getTiming().upper; // request descartes timing
+    if (time_step == 0.0) from_start += ros::Duration(DEFAULT_TIME_UNDEFINED_VELOCITY); // default time
+    else from_start += ros::Duration(time_step);
+
+    pt.time_from_start = from_start;
+
+    ros_trajectory.points.push_back(pt);
+  }
+
+  return ros_trajectory;
+}
+
+void godel_process_planning::fillTrajectoryHeaders(const std::vector<std::string>& joints,
+                                                    trajectory_msgs::JointTrajectory& traj)
+{
+  traj.joint_names = joints;
+  traj.header.frame_id = DEFAULT_FRAME_ID;
+  traj.header.stamp = ros::Time::now();
+}
+
+std::vector<double> godel_process_planning::getCurrentJointState(const std::string& topic)
+{
+  sensor_msgs::JointStateConstPtr state = ros::topic::waitForMessage<sensor_msgs::JointState>(topic, ros::Duration(DEFAULT_JOINT_WAIT_TIME));
+  if (!state) throw std::runtime_error("Joint state message capture failed");
+  return state->position;
+}
+
+godel_process_planning::DescartesTraj
+godel_process_planning::createLinearPath(const Eigen::Affine3d &start,
+                                         const Eigen::Affine3d &stop,
+                                         double ds)
+{
+  using namespace descartes_trajectory;
+
+  PoseVector cart_path = interpolateCartesian(start, stop, ds);
+  DescartesTraj result;
+  for (std::size_t i = 0; i < cart_path.size(); ++i)
+  {
+    result.push_back(boost::make_shared<AxialSymmetricPt>(cart_path[i],
+                                                          DEFAULT_ANGLE_DISCRETIZATION,
+                                                          descartes_trajectory::AxialSymmetricPt::Z_AXIS));
+  }
+
+  return result;
+}
+
+
+godel_process_planning::DescartesTraj
+godel_process_planning::createJointPath(const std::vector<double> &start,
+                                        const std::vector<double> &stop,
+                                        double dtheta)
+{
+  JointVector path = interpolateJoint(start, stop, dtheta);
+  DescartesTraj result;
+  for (std::size_t i = 0; i < path.size(); ++i)
+  {
+    result.push_back(boost::make_shared<descartes_trajectory::JointTrajectoryPt>(path[i]));
+  }
+  return result;
+}
+
+
+trajectory_msgs::JointTrajectory godel_process_planning::getMoveitPlan(const std::string &group_name,
+                                                                       const std::vector<double> &joints_start,
+                                                                       const std::vector<double> &joints_stop,
+                                                                       moveit::core::RobotModelConstPtr model)
+{
+  const moveit::core::JointModelGroup* group = model->getJointModelGroup(group_name);
+  robot_state::RobotState goal_state(model);
+  goal_state.setJointGroupPositions(group, joints_stop);
+
+  moveit_msgs::GetMotionPlan::Request req;
+  req.motion_plan_request.group_name = group_name;
+  req.motion_plan_request.num_planning_attempts = DEFAULT_MOVEIT_NUM_PLANNING_ATTEMPTS;
+  req.motion_plan_request.max_velocity_scaling_factor = DEFAULT_MOVEIT_VELOCITY_SCALING;
+  req.motion_plan_request.allowed_planning_time = DEFAULT_MOVEIT_PLANNING_TIME;
+  req.motion_plan_request.planner_id = DEFAULT_MOVEIT_PLANNER_ID;
+
+  req.motion_plan_request.workspace_parameters.header.frame_id = model->getRootLinkName();
+  req.motion_plan_request.workspace_parameters.header.stamp = ros::Time::now();
+
+  // Set the start state
+  // Will want to add options here to start from a state that's not the start state
+  moveit_msgs::RobotState start_state;
+  start_state.is_diff = false;
+  sensor_msgs::JointState joint_state;
+  joint_state.name = group->getActiveJointModelNames();
+  joint_state.position = joints_start;
+  start_state.joint_state = joint_state;
+  req.motion_plan_request.start_state = start_state;
+
+  // Set the goal state
+  moveit_msgs::Constraints c = kinematic_constraints::constructGoalConstraints(goal_state, group);
+  req.motion_plan_request.goal_constraints.push_back(c);
+
+  // Make connection the planning-service offered by the MoveIt MoveGroup node
+  ros::NodeHandle nh;
+  ros::ServiceClient client = nh.serviceClient<moveit_msgs::GetMotionPlan>(DEFAULT_MOVEIT_PLANNING_SERVICE_NAME);
+
+  trajectory_msgs::JointTrajectory jt;
+  moveit_msgs::GetMotionPlan::Response res;
+  if (client.call(req, res))
+  {
+    jt = res.motion_plan_response.trajectory.joint_trajectory;
+  }
+  else
+  {
+    ROS_ERROR("%s: Unable to call MoveIt path planning service: '%s' or planning failed", __FUNCTION__, DEFAULT_MOVEIT_PLANNING_SERVICE_NAME.c_str());
+    throw std::runtime_error("Unable to generate MoveIt path plan");
+  }
+  return jt;
+}
+
+trajectory_msgs::JointTrajectory
+godel_process_planning::planFreeMove(descartes_core::RobotModel& model,
+                                     const std::string& group_name,
+                                     moveit::core::RobotModelConstPtr moveit_model,
+                                     const std::vector<double>& start,
+                                     const std::vector<double>& stop)
+{
+  // Using a mutable model, turns collision checking on for just the
+  // period of this function. Functions called in this function may
+  // throw exceptions and this makes sure the system state is always
+  // valid
+  struct CollisionsGuard {
+    CollisionsGuard(descartes_core::RobotModel& model) : model_(model) {
+      model.setCheckCollisions(true);
+      ROS_WARN_STREAM("Enabling collision");
+    }
+    ~CollisionsGuard() {
+      model_.setCheckCollisions(false);
+      ROS_WARN_STREAM("Disable collision");
+    }
+    descartes_core::RobotModel& model_;
+  };
+
+  // Create gaurd to enable collisions only for this function
+  CollisionsGuard guard (model);
+
+  // Attempt joint interpolated motion
+  DescartesTraj joint_approach = createJointPath(start, stop);
+
+  // Check approach for collisions
+  bool collision_free = true;
+  for (std::size_t i = 0; i < joint_approach.size(); ++i)
+  {
+    if (!joint_approach[i]->isValid(model))
+    {
+      collision_free = false;
+      break;
+    }
+  }
+
+  // If the method is collision free, then we use the interpolation
+  // otherwise let moveit try
+  if (collision_free)
+  {
+    return toROSTrajectory(joint_approach, model);
+  }
+  else
+  {
+    return godel_process_planning::getMoveitPlan(group_name, start, stop, moveit_model);
+  }
+}

--- a/godel_process_planning/src/common_utils.h
+++ b/godel_process_planning/src/common_utils.h
@@ -1,0 +1,126 @@
+#ifndef COMMON_UTILS_H
+#define COMMON_UTILS_H
+
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/Point.h>
+
+#include <descartes_core/trajectory_pt.h>
+#include <descartes_core/robot_model.h>
+
+#include <sensor_msgs/JointState.h>
+
+#include <Eigen/Geometry>
+
+namespace godel_process_planning
+{
+  typedef std::vector<descartes_core::TrajectoryPtPtr> DescartesTraj;
+
+/**
+   * @brief Converts a point relative to given pose into a robot tool pose (i.e. flip z)
+   * @param ref_pose Reference pose (in world frame) for 'pt'
+   * @param pt 3-dimensional offset from pose for the given point
+   * @return Tool pose corresponding to this surface point
+   */
+  Eigen::Affine3d createNominalTransform(const geometry_msgs::Pose& ref_pose,
+                                         const geometry_msgs::Point& pt);
+
+  /**
+   * @brief Given a path and robot model, this method creates a descartes planner and attempts to solve the path
+   * @param in_path Trajectory to solve
+   * @param robot_model Robot model used for IK/FK by planner
+   * @param out_path The solution path, if found, otherwise undefined
+   * @return True if path was found and result placed inside 'out_path'; False otherwise.
+   */
+  bool descartesSolve(const DescartesTraj& in_path,
+                      descartes_core::RobotModelConstPtr robot_model,
+                      DescartesTraj& out_path);
+  /**
+   * @brief Extracts joint position values from Descartes trajectory and packs them into a ROS message
+   * @param solution The Descartes trajectory used to generate nominal joint trajectory
+   * @param model The robot model used in generating the above trajectory
+   * @return A ROS joint trajectory with only the 'points' field filled in; you must add header/joint name info
+   */
+  trajectory_msgs::JointTrajectory toROSTrajectory(const DescartesTraj& solution,
+                                                   const descartes_core::RobotModel& model);
+  /**
+   * @brief Updates the joint names, frame id, and time stamp of the given trajectory
+   * @param joints Joint names; listed in same order as the values they correspond to
+   * @param traj The trajectory to modify
+   */
+  void fillTrajectoryHeaders(const std::vector<std::string>& joints,
+                             trajectory_msgs::JointTrajectory& traj);
+
+  /**
+   * @brief Attempts to capture the most recent JointState from the given topic
+   * @param topic The joint topic name on which to listen for the robot state
+   * @return The joint positions captured from the topic or a std::runtime_error
+   */
+  std::vector<double> getCurrentJointState(const std::string& topic);
+
+  /**
+   * @brief Creates descartes trajectory consisting of cartesian positions in a linear path between start and stop
+   * @param start The start pose of the linear interpolation
+   * @param stop The final pose of the linear interpolation
+   * @param ds The distance (m) between points in the linear path; defaults to 10cm
+   * @return A linear interpolated path from start to stop in Descartes format
+   */
+  DescartesTraj createLinearPath(const Eigen::Affine3d& start,
+                                 const Eigen::Affine3d& stop,
+                                 double ds = 0.1);
+  /**
+   * @brief Creates descartes trajectory consisting of joint interpolated positions from start to stop
+   * @param start The initial joint configuration
+   * @param stop The final joint configuration
+   * @param dtheta The maximum angle change (radians) for any joint between sequential points
+   * @return A joint-interpolated path from start to stop in Descartes format
+   */
+  DescartesTraj createJointPath(const std::vector<double>& start,
+                                const std::vector<double>& stop,
+                                double dtheta = M_PI / 180.0);
+  /**
+   * @brief Invokes MoveGroup's 'plan_kinematic_path' service to create a collision free path between joints_start and joints_stop
+   * @brief group_name The name of the MoveIt move-group associated with this plan
+   * @param joints_start The initial robot configuration
+   * @param joints_stop The target robot configuration
+   * @param model The MoveIt model containing the move-group 'group_name'
+   * @return Joint Trajectory represeting motion from joints_start to joints_stop; or std::runtime_error
+   */
+  trajectory_msgs::JointTrajectory getMoveitPlan(const std::string& group_name,
+                                                 const std::vector<double>& joints_start,
+                                                 const std::vector<double>& joints_stop,
+                                                 moveit::core::RobotModelConstPtr model);
+  /**
+   * @brief A helper function to make getting the nominal joint value out of a Descartes point more concise
+   * @param model The associated Descartes robot model
+   * @param pt Descartes trajectory point from which to pull the joint values
+   * @return The joint values from 'pt' obtained as a result of a call to getNominalJointPose()
+   */
+  static inline
+  std::vector<double> extractJoints(const descartes_core::RobotModel& model,
+                                    const descartes_core::TrajectoryPt& pt)
+  {
+    std::vector<double> dummy, result;
+    pt.getNominalJointPose(dummy, model, result);
+    return result;
+  }
+
+  /**
+   * @brief A planning helper function for getting a valid path between start and stop; first attempts a joint interpolated motion
+   *        to see if its collision free. If not, it invokes MoveIt as a backup.
+   * @param model Associated descartes robot model
+   * @param group_name Name of moveit move-group associated with the moveit model
+   * @param moveit_model the moveit robot description associated with this item
+   * @param start Initial robot configuration
+   * @param stop Final robot configuration
+   * @return A collision-free path from start to stop
+   */
+  trajectory_msgs::JointTrajectory planFreeMove(descartes_core::RobotModel& model,
+                                                const std::string &group_name,
+                                                moveit::core::RobotModelConstPtr moveit_model,
+                                                const std::vector<double>& start,
+                                                const std::vector<double>& stop);
+
+}
+
+#endif // COMMON_UTILS_H
+

--- a/godel_process_planning/src/godel_process_planning.cpp
+++ b/godel_process_planning/src/godel_process_planning.cpp
@@ -1,0 +1,46 @@
+#include "godel_process_planning/godel_process_planning.h"
+#include <moveit/robot_model_loader/robot_model_loader.h>
+
+godel_process_planning::ProcessPlanningManager::ProcessPlanningManager(const std::string &world_frame,
+                                                                       const std::string &blend_group,
+                                                                       const std::string &blend_tcp,
+                                                                       const std::string &keyence_group,
+                                                                       const std::string &keyence_tcp,
+                                                                       const std::string &robot_model_plugin)
+  : plugin_loader_("descartes_core", "descartes_core::RobotModel")
+  , blend_group_name_(blend_group)
+  , keyence_group_name_(keyence_group)
+{
+  // Attempt to load and initialize the blending robot model
+  blend_model_ = plugin_loader_.createInstance(robot_model_plugin);
+  if (!blend_model_)
+  {
+    throw std::runtime_error(std::string("Could not load: ") + robot_model_plugin);
+  }
+
+  if (!blend_model_->initialize("robot_description", blend_group, world_frame, blend_tcp))
+  {
+    throw std::runtime_error("Unable to initialize blending robot model");
+  }
+
+  // Attempt to load and initialize the scanning/keyence robot model
+  keyence_model_ = plugin_loader_.createInstance(robot_model_plugin);
+  if (!keyence_model_)
+  {
+    throw std::runtime_error(std::string("Could not load: ") + robot_model_plugin);
+  }
+
+  if (!keyence_model_->initialize("robot_description", keyence_group, world_frame, keyence_tcp))
+  {
+    throw std::runtime_error("Unable to initialize scanning robot model");
+  }
+
+  // Load the moveit model
+  robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
+  moveit_model_ = robot_model_loader.getModel();
+
+  if (moveit_model_.get() == NULL)
+  {
+    throw std::runtime_error("Could not load moveit robot model");
+  }
+}

--- a/godel_process_planning/src/godel_process_planning_node.cpp
+++ b/godel_process_planning/src/godel_process_planning_node.cpp
@@ -1,0 +1,44 @@
+#include <ros/ros.h>
+// Process Services
+#include <godel_process_planning/godel_process_planning.h>
+
+// Globals
+const static std::string DEFAULT_BLEND_PLANNING_SERVICE = "blend_process_planning";
+const static std::string DEFAULT_KEYENCE_PLANNING_SERVICE = "keyence_process_planning";
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "godel_process_planning");
+
+  // Load local parameters
+  ros::NodeHandle nh, pnh("~");
+  std::string world_frame, blend_group, keyence_group, blend_tcp, keyence_tcp, robot_model_plugin;
+  pnh.param<std::string>("world_frame", world_frame, "world_frame");
+  pnh.param<std::string>("blend_group", blend_group, "manipulator_tcp");
+  pnh.param<std::string>("keyence_group", keyence_group, "manipulator_keyence");
+  pnh.param<std::string>("blend_tcp", blend_tcp, "tcp_frame");
+  pnh.param<std::string>("keyence_tcp", keyence_tcp, "keyence_tcp_frame");
+  pnh.param<std::string>("robot_model_plugin", robot_model_plugin, "");
+
+  // IK Plugin parameter must be specified
+  if (ik_plugin.empty())
+  {
+    ROS_ERROR_STREAM("MUST SPECIFY PARAMETER 'ik_plugin' for godel_process_planning node");
+    return -1;
+  }
+
+  using godel_process_planning::ProcessPlanningManager;
+
+  // Creates a planning manager that will create the appropriate planning classes and perform
+  // all required initialization. It exposes member functions to handle each kind of processing event.
+  ProcessPlanningManager manager(world_frame, blend_group, blend_tcp, keyence_group, keyence_tcp, robot_model_plugin);
+  // Plumb in the appropriate ros services
+  ros::ServiceServer blend_server = nh.advertiseService(DEFAULT_BLEND_PLANNING_SERVICE, &ProcessPlanningManager::handleBlendPlanning, &manager);
+  ros::ServiceServer keyence_server = nh.advertiseService(DEFAULT_KEYENCE_PLANNING_SERVICE, &ProcessPlanningManager::handleKeyencePlanning, &manager);
+
+  // Serve and wait for shutdown
+  ROS_INFO_STREAM("Godel Process Planning Server Online");
+  ros::spin();
+
+  return 0;
+}

--- a/godel_process_planning/src/keyence_process_planning.cpp
+++ b/godel_process_planning/src/keyence_process_planning.cpp
@@ -1,0 +1,159 @@
+#include <godel_process_planning/godel_process_planning.h>
+
+#include <ros/console.h>
+
+// descartes
+#include "descartes_trajectory/cart_trajectory_pt.h"
+#include "descartes_planner/dense_planner.h"
+
+#include "common_utils.h"
+
+// FILE LOCAL CONSTANTS
+const static std::string JOINT_TOPIC_NAME = "joint_states"; // ROS topic to subscribe to for robot state
+
+namespace godel_process_planning
+{
+
+/**
+ * @brief Translated an Eigen pose to a Descartes trajectory point appropriate for the scan process!
+ *        Mirros the function in blend_process_planning.cpp document.
+ * @param pose
+ * @param dt The upper limit of time from the previous point to achieve this one
+ * @return A descartes trajectory point encapsulating a move to this pose
+ */
+static inline descartes_core::TrajectoryPtPtr toDescartesPt(const Eigen::Affine3d& pose, double dt)
+{
+  using namespace descartes_trajectory;
+  using namespace descartes_core;
+  const descartes_core::TimingConstraint tm (dt);
+
+  Eigen::Vector3d rpy = pose.rotation().eulerAngles(0,1,2);
+  Eigen::Vector3d xyz = pose.translation();
+
+  double rx = rpy(0), ry = rpy(1), rz = rpy(2);
+  double x = xyz(0), y = xyz(1), z = xyz(2);
+
+  // By specifying a range of 180 degrees and a step of 180 degrees, the system will sample
+  // at the nominal pose +/- 90 degrees for scanning purposes.
+  TolerancedFrame frame (pose,
+                         ToleranceBase::zeroTolerance<PositionTolerance>(x,y,z),
+                         ToleranceBase::createSymmetric<OrientationTolerance>(rx,ry,rz,0,0,M_PI));
+
+  return TrajectoryPtPtr(new CartTrajectoryPt(frame, 0.0, M_PI, tm));
+}
+
+/**
+ * @brief transforms an input, in the form of a reference pose and points relative to that pose, into Descartes'
+ *        native format. Also adds in associated parameters.
+ * @param ref The reference posed that all points are multiplied by. Should be in the world space of the keyence move group.
+ * @param points Sequence of points (relative to ref and the world space of blending robot model)
+ * @param params Surface blending parameters, including info such as traversal speed
+ * @return The input trajectory encoded in Descartes points
+ */
+static godel_process_planning::DescartesTraj toDescartesTraj(const geometry_msgs::Pose& ref,
+                                                             const std::vector<geometry_msgs::Point>& points,
+                                                             const godel_msgs::ScanPlanParameters& params)
+{
+  DescartesTraj traj;
+  traj.reserve(points.size());
+  if (points.empty()) return traj;
+
+  Eigen::Affine3d last_pose = createNominalTransform(ref, points.front());
+
+  for (std::size_t i = 0; i < points.size(); ++i)
+  {
+    Eigen::Affine3d this_pose = createNominalTransform(ref, points[i]);
+    double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
+    traj.push_back( toDescartesPt(this_pose, dt) );
+    last_pose = this_pose;
+  }
+
+  return traj;
+}
+
+/**
+ * @brief Computes a joint motion plan based on input points and the scan process; this includes
+ *        motion from current position to process path and back to the starting position.
+ * @param req Process plan including reference pose, points, and process parameters
+ * @param res Set of approach, process, and departure trajectories
+ * @return True if a valid plan was generated; false otherwise
+ */
+bool ProcessPlanningManager::handleKeyencePlanning(godel_msgs::KeyenceProcessPlanning::Request& req,
+                                                   godel_msgs::KeyenceProcessPlanning::Response& res)
+{
+  // Precondition: Input trajectory must be non-zero
+  if (req.path.points.empty())
+  {
+    ROS_WARN("%s: Cannot create scan process plan for empty trajectory",  __FUNCTION__);
+    return false;
+  }
+
+  // Transform process path from geometry msgs to descartes points
+  DescartesTraj process_points = toDescartesTraj(req.path.reference, req.path.points, req.params);
+  DescartesTraj solved_path;
+
+  // Capture the current state of the robot
+  std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
+
+  // Current pose
+  Eigen::Affine3d init_pose;
+  keyence_model_->getFK(current_joints, init_pose);
+
+  // Calculate nominal pose of initial process point
+  Eigen::Affine3d process_start_pose;
+  process_points.front()->getNominalCartPose(std::vector<double>(), *keyence_model_, process_start_pose);
+
+  // Calculate nominal pose of final process point
+  Eigen::Affine3d process_stop_pose;
+  process_points.back()->getNominalCartPose(std::vector<double>(), *keyence_model_, process_stop_pose);
+
+  // Create interpolation segment from init position to process path
+  DescartesTraj to_process = createLinearPath(init_pose, process_start_pose);
+  to_process.front() = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
+
+  // Create interpolation segment from end of process path to init position
+  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
+  from_process.back() = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
+
+  // Stitch the above approach and departure trajectories in with the original path
+  DescartesTraj seed_path;
+  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
+  seed_path.insert(seed_path.end(), process_points.begin(), process_points.end());
+  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
+
+  // Attempt to solve the initial path
+  if (!descartesSolve(seed_path, keyence_model_, solved_path))
+  {
+    return false;
+  }
+
+  // Refine the approach and depart plans by attempting joint interpolation and using MoveIt if necessary
+  trajectory_msgs::JointTrajectory approach = planFreeMove(*keyence_model_, keyence_group_name_, moveit_model_,
+                                                           extractJoints(*keyence_model_, *solved_path[0]),
+                                                           extractJoints(*keyence_model_, *solved_path[to_process.size()]));
+
+  trajectory_msgs::JointTrajectory depart = planFreeMove(*keyence_model_, keyence_group_name_, moveit_model_,
+                                                         extractJoints(*keyence_model_, *solved_path[to_process.size() + process_points.size() -1]),
+                                                         extractJoints(*keyence_model_, *solved_path[seed_path.size() - 1]));
+  // Segment out process path from initial solution
+  DescartesTraj process_part (solved_path.begin() + to_process.size(), solved_path.end() - from_process.size());
+  trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *keyence_model_);
+
+  // Translate the Descartes trajectory into a ROS joint trajectory
+  const std::vector< std::string >& joint_names =
+      moveit_model_->getJointModelGroup(keyence_group_name_)->getActiveJointModelNames();
+
+  res.plan.trajectory_process = process;
+  res.plan.trajectory_approach = approach;
+  res.plan.trajectory_depart = depart;
+
+  godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_approach);
+  godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_depart);
+  godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_process);
+
+  res.plan.type = godel_msgs::ProcessPlan::SCAN_TYPE;
+
+  return true;
+}
+
+}

--- a/godel_process_planning/src/trajectory_utils.cpp
+++ b/godel_process_planning/src/trajectory_utils.cpp
@@ -1,0 +1,101 @@
+#include "trajectory_utils.h"
+
+
+//////////////////////////////////////////////
+// Helper Functions for joint interpolation //
+//////////////////////////////////////////////
+
+static unsigned int calculateRequiredSteps(const std::vector<double>& start,
+                                           const std::vector<double>& stop,
+                                           double dtheta)
+{
+  // calculate max steps required
+  unsigned steps = 0;
+  for (std::size_t i = 0; i < start.size() ; ++i)
+  {
+    unsigned this_joint_steps = static_cast<unsigned>(std::abs(start[i] - stop[i]) / dtheta);
+    steps = std::max(steps, this_joint_steps);
+  }
+
+  return steps;
+}
+
+static std::vector<double> calculateJointSteps(const std::vector<double>& start,
+                                               const std::vector<double>& stop,
+                                               unsigned int steps)
+{
+  // Given max steps, calculate delta for each joint
+  std::vector<double> result;
+  result.reserve(start.size());
+
+  for (std::size_t i = 0; i < start.size(); ++i)
+  {
+    result.push_back((stop[i] - start[i]) / steps);
+  }
+
+  return result;
+}
+
+static std::vector<double> interpolateJointSteps(const std::vector<double>& start,
+                                                 const std::vector<double>& step_size,
+                                                 unsigned step)
+{
+    std::vector<double> result;
+    result.reserve(start.size());
+    for (std::size_t i = 0; i < start.size(); ++i)
+        result.push_back( start[i] + step_size[i] * step );
+    return result;
+}
+
+
+
+godel_process_planning::PoseVector
+godel_process_planning::interpolateCartesian(const Eigen::Affine3d &start,
+                                             const Eigen::Affine3d &stop,
+                                             double ds)
+{
+  // Required position change
+  Eigen::Vector3d delta = (stop.translation() - start.translation());
+  Eigen::Vector3d start_pos = start.translation();
+
+  // Calculate number of steps
+  unsigned steps = static_cast<unsigned>(delta.norm() / ds) + 1;
+
+  // Step size
+  Eigen::Vector3d step = delta / steps;
+
+  // Orientation interpolation
+  Eigen::Quaterniond start_q (start.rotation());
+  Eigen::Quaterniond stop_q (stop.rotation());
+  double slerp_ratio = 1.0 / steps;
+
+  godel_process_planning::PoseVector result;
+  result.reserve(steps);
+  for (unsigned i = 0; i <= steps; ++i)
+  {
+    Eigen::Vector3d trans = start_pos + step * i;
+    Eigen::Quaterniond q = start_q.slerp(slerp_ratio * i, stop_q);
+    Eigen::Affine3d pose (Eigen::Translation3d(trans) * q);
+    result.push_back(pose);
+  }
+  return result;
+}
+
+
+godel_process_planning::JointVector
+godel_process_planning::interpolateJoint(const std::vector<double> &start,
+                                         const std::vector<double> &stop,
+                                         double dtheta)
+{
+  godel_process_planning::JointVector result;
+  // joint delta
+  unsigned steps = calculateRequiredSteps(start, stop, dtheta);
+  std::vector<double> delta = calculateJointSteps(start, stop, steps);
+  // Walk interpolation
+  for (std::size_t i = 0; i <= steps; ++i)
+  {
+      std::vector<double> pos = interpolateJointSteps(start, delta, i);
+      result.push_back(pos);
+  }
+  return result;
+}

--- a/godel_process_planning/src/trajectory_utils.h
+++ b/godel_process_planning/src/trajectory_utils.h
@@ -1,0 +1,38 @@
+#ifndef TRAJECTORY_UTILS_H
+#define TRAJECTORY_UTILS_H
+
+#include <Eigen/Geometry>
+
+namespace godel_process_planning
+{
+  // Cartesian Interpolation
+  typedef std::vector<Eigen::Affine3d, Eigen::aligned_allocator<Eigen::Affine3d> > PoseVector;
+
+/**
+   * @brief Creates a vector of poses representing linear spatial and rotational interpolation
+   *        between starting and ending poses.
+   * @param start Beginning pose
+   * @param stop Terminating pose
+   * @param ds The cartesian distance (m) between intermediate points
+   * @return Sequence of poses
+   */
+  PoseVector
+  interpolateCartesian(const Eigen::Affine3d& start, const Eigen::Affine3d& stop, double ds);
+
+  // Joint Interpolation
+  typedef std::vector<std::vector<double> > JointVector;
+
+  /**
+   * @brief Creates a vector of joint poses linearly interpolating from start to stop
+   * @param start Initial joint configuration
+   * @param stop Final joint configuration
+   * @param dtheta Maximum joint step (radians) between intermediate points
+   * @return
+   */
+  JointVector
+  interpolateJoint(const std::vector<double>& start, const std::vector<double>& stop,
+                   double dtheta);
+
+}
+
+#endif


### PR DESCRIPTION
The process planning service was the eventual evolution of the path planner. It not only uses Descartes to do cartesian path trajectory planning, but also throws in moveit and some simple linear interpolators to calculate the approach and departure paths. 

I'm throwing this code up here as is, and I will also review it myself so I have a record of the ultimate changes I'm making relative to the version I'm moving to.
