### PR TITLE
Indigo Build Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C
 - Cd into the 'src' directory of your catkin workspace and run the following:
   ```
   wstool init . 
-  wstool merge https://github.com/ros-industrial-consortium/godel/raw/hydro-devel/godel.rosinstall
+  wstool merge https://github.com/ros-industrial-consortium/godel/raw/indigo-devel/godel.rosinstall
   wstool update
   rosdep install --from-paths . --ignore-src
   cd ..

--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,6 +1,8 @@
 - git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git',
-    version: hydro-devel}
+    version: indigo-devel}
 - git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git',
     version: hydro-devel}
 - git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git',
-    version: hydro-devel}
+    version: indigo-devel}
+- git: {local-name: motoman, uri: 'https://github.com/ros-industrial/motoman.git',
+    version: indigo-devel}


### PR DESCRIPTION
This PR updates the rosinstall file to bring down `motoman` in addition to the `indigo-devel` branches of a few of the other packages. Readme instructions updated to match.
