### PR TITLE
ABB RAPID Alternate Driver

### DIFF
--- a/godel_robots/abb/abb_file_suite/CMakeLists.txt
+++ b/godel_robots/abb/abb_file_suite/CMakeLists.txt
@@ -1,0 +1,85 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(abb_file_suite)
+
+find_package(catkin REQUIRED COMPONENTS
+  message_generation
+  roscpp
+  trajectory_msgs
+)
+
+add_service_files(
+  FILES
+  ExecuteProgram.srv
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
+
+catkin_package(
+  INCLUDE_DIRS 
+    include 
+    rapid_generator/include
+  LIBRARIES 
+    ros_abb_ftp_interface
+    rapid_generator
+  CATKIN_DEPENDS 
+    roscpp 
+    trajectory_msgs 
+    message_runtime
+  DEPENDS
+    curl
+)
+
+###########
+## Build ##
+###########
+
+# Subproject 'rapid_generator'
+add_subdirectory(rapid_generator)
+
+include_directories(
+  include
+  rapid_generator/include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+add_library(ros_abb_ftp_interface
+ src/abb_motion_ftp_downloader.cpp
+ src/ftp_upload.cpp
+)
+
+add_executable(ros_abb_ftp_interface_node src/abb_motion_ftp_downloader_node.cpp)
+
+add_dependencies(ros_abb_ftp_interface_node abb_file_suite_generate_messages_cpp)
+
+target_link_libraries(ros_abb_ftp_interface
+  rapid_generator
+  curl
+)
+
+target_link_libraries(ros_abb_ftp_interface_node
+ ros_abb_ftp_interface
+ ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+
+# Mark executables and/or libraries for installation
+install(TARGETS rapid_generator ros_abb_ftp_interface ros_abb_ftp_interface_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Mark cpp header files for installation
+install(DIRECTORY include rapid_generator/include
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)

--- a/godel_robots/abb/abb_file_suite/README.md
+++ b/godel_robots/abb/abb_file_suite/README.md
@@ -1,0 +1,13 @@
+# abb_file_suite
+A suite of tools used for interfacing ROS-I and an ABB robot through the use of module files that are generated and downloaded on the fly.
+
+## ABB Controller Side
+The `abb_motion_ftp_downloader` interface uses the standard ROS-I State Server and a custom motion server. Files for it can be found under the `rapid/` subdirectory. The system works by listening for the existence of a specific file in the `HOME/PARTMODULES` directory on the controller. Files are uploaded via FTP using [libcurl](http://curl.haxx.se/libcurl/). This library can be downloaded through the apt-get interface:
+
+```
+sudo apt-get install libcurl4-openssl-dev
+```
+
+## Rapid Generator
+When using the Rapid generation routines, be sure to flush/close your output file before sending it to the 'execute program' service. 
+

--- a/godel_robots/abb/abb_file_suite/include/abb_file_suite/abb_motion_ftp_downloader.h
+++ b/godel_robots/abb/abb_file_suite/include/abb_file_suite/abb_motion_ftp_downloader.h
@@ -1,0 +1,54 @@
+#ifndef ABB_MOTION_FTP_DOWNLOADER_H
+#define ABB_MOTION_FTP_DOWNLOADER_H
+
+#include <ros/subscriber.h>
+#include <ros/service_server.h>
+#include <trajectory_msgs/JointTrajectory.h>
+#include "abb_file_suite/ExecuteProgram.h"
+
+namespace abb_file_suite
+{
+
+/**
+ * @brief The class provides an alternative driver interface to ABB robots
+ *        running an FTP server. It offers a joint trajectory interface and
+ *        a service that can execute arbitrary RAPID scripts.
+ */
+class AbbMotionFtpDownloader
+{
+public:
+  AbbMotionFtpDownloader(const std::string& ip,
+                         const std::string& listen_topic,
+                         ros::NodeHandle& nh,
+                         bool j23_coupled = false,
+                         const std::string& temp_file_loc = std::string("/tmp"));
+
+  /**
+   * Callback handler that executes a new joint trajectory. This is accomplished
+   * by writing a RAPID file that encodes the requested joint motions and timing.
+   * This file is then uploaded via FTP
+   */
+  void handleJointTrajectory(const trajectory_msgs::JointTrajectory& traj);
+
+  /**
+   * This service call handler will attempt to directly upload a RAPID file
+   * to the robot from the path given in the request.
+   * @param  req Contains the ABSOLUTE path the RAPID file to upload
+   * @param  res No fields in the return value
+   * @return     True if the FTP transfer was completed; note this doesn't mean the robot
+   *             succeeded or even read the complete file. 
+   */
+  bool handleServiceCall(abb_file_suite::ExecuteProgram::Request& req,
+                         abb_file_suite::ExecuteProgram::Response& res);
+
+private:
+  ros::Subscriber trajectory_sub_;
+  ros::ServiceServer server_;
+  const std::string ip_;
+  const std::string temp_file_loc_;
+  bool j23_coupled_; /** joints 2 and 3 are coupled (as in ABB IRB2400) */
+};
+
+}
+
+#endif

--- a/godel_robots/abb/abb_file_suite/package.xml
+++ b/godel_robots/abb/abb_file_suite/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package>
+  <name>abb_file_suite</name>
+  <version>0.1.0</version>
+  <description>
+    An alternative ROS driver for the ABB series of robots that creates RAPID programs
+    in code and then FTPs the results to the robot for execution. 
+  </description>
+
+  <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
+
+  <author email="jmeyer@swri.org">Jonathan Meyer</author>
+  <author email="Zachary.Bennett@wolfrobotics.com">Zach Bennett</author>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>trajectory_msgs</build_depend>
+
+  <run_depend>roscpp</run_depend>
+  <run_depend>trajectory_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
+</package>

--- a/godel_robots/abb/abb_file_suite/rapid/mGodel_Main.mod
+++ b/godel_robots/abb/abb_file_suite/rapid/mGodel_Main.mod
@@ -1,0 +1,19 @@
+MODULE mGodel_DemoMain
+    PROC Godel_Main()
+        !Delete Files if they exist
+        IF IsFile("HOME:/PARTMODULES/mGodelBlend.mod") RemoveFile "HOME:/PARTMODULES/mGodelBlend.mod";
+        IF ModExist("mGodel_Blend") EraseModule("mGodel_Blend");
+        
+        WHILE true DO
+          !Wait for Blend File
+          WaitUntil IsFile("HOME:/PARTMODULES/mGodelBlend.mod");
+          WaitTime 0.25;
+          Load "HOME:/PartModules" \File:="mGodelBlend.MOD";
+          %"Godel_Blend"%;
+          UnLoad "HOME:/PartModules" \File:="mGodelBlend.MOD";
+          RemoveFile "HOME:/PARTMODULES/mGodelBlend.mod";
+        ENDWHILE
+        !
+    ENDPROC
+    
+ENDMODULE

--- a/godel_robots/abb/abb_file_suite/rapid_generator/CMakeLists.txt
+++ b/godel_robots/abb/abb_file_suite/rapid_generator/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(rapid_generator)
+
+include_directories(include)
+add_library(rapid_generator src/rapid_emitter.cpp)

--- a/godel_robots/abb/abb_file_suite/rapid_generator/include/rapid_generator/rapid_data_structures.h
+++ b/godel_robots/abb/abb_file_suite/rapid_generator/include/rapid_generator/rapid_data_structures.h
@@ -1,0 +1,46 @@
+#ifndef RAPID_DATA_STRUCTURES_H
+#define RAPID_DATA_STRUCTURES_H
+
+#include <vector>
+#include <string>
+
+namespace rapid_emitter
+{
+
+/**
+ * @brief A joint trajectory point that can be converted to a RAPID
+ *        joint target.
+ */
+struct TrajectoryPt
+{
+  typedef std::vector<double> value_type;
+
+  TrajectoryPt(const std::vector<double>& positions, double duration = 0.0)
+    : positions_(positions)
+    , duration_(duration)
+  {}
+
+  value_type positions_; // degrees
+  double duration_; // seconds
+};
+
+/**
+ * @brief This structure is used in combination with a vector of trajectory points to
+ *        generate any entire rapid program. Some fields aren't used by the default
+ *        software, but interact with proprietary extensions like Wolf Robotic's
+ *        Wolfware.
+ */
+struct ProcessParams
+{
+  double spindle_speed; // Tool rotation speed
+  double tcp_speed; // Tool linear traversal speed
+  double force; // For non-wolfware software, a general identification of force
+  std::string output_name; // The I/O that toggles the tool power; We assume 0 is off and 1 is on.
+  bool wolf_mode; // In the case of Wolfware software, we emit special instructions.
+  double slide_force; // For WolfWare, a meaure of the cross-slide force (?)
+};
+
+}
+
+#endif // RAPID_DATA_STRUCTURES_H
+

--- a/godel_robots/abb/abb_file_suite/rapid_generator/include/rapid_generator/rapid_emitter.h
+++ b/godel_robots/abb/abb_file_suite/rapid_generator/include/rapid_generator/rapid_emitter.h
@@ -1,0 +1,53 @@
+#ifndef RAPID_EMITTER_H
+#define RAPID_EMITTER_H
+
+#include "rapid_generator/rapid_data_structures.h"
+
+#include <iosfwd>
+#include <string>
+
+
+namespace rapid_emitter
+{
+  /**
+   * @brief Writes a RAPID program to 'os' that moves through a sequence of joint positions
+   *        and toggles an I/O on and off at specific sequence points.
+   * @param os  The output stream; will usually be a std::ofstream
+   * @param points  Sequence of joint-positions and durations
+   * @param startProcessMotion  The first joint-position inside the 'process' segment of the points array
+   * @param endProcessMotion The final joint-position inside the 'process' segment of the points array
+   * @param params Process parameters such as tool velocity
+   * @return Success if the file was successfully generated
+   */
+  bool emitRapidFile(std::ostream& os,
+                     const std::vector<TrajectoryPt>& points,
+                     size_t startProcessMotion,
+                     size_t endProcessMotion,
+                     const ProcessParams& params);
+
+  /**
+   * @brief Writes a RAPID program to 'os' that merely moves through a sequence of points.
+   * @param os  The output stream; will usually be std::ofstream
+   * @param points  Sequence of joint positions and durations to move through
+   * @param params  These parameters are used to provide default motion speeds if duration is left emtpy
+   * @return True is the file was successfully generated
+   */
+  bool emitJointTrajectoryFile(std::ostream& os,
+                               const std::vector<TrajectoryPt>& points,
+                               const ProcessParams& params);
+
+  /** Helper Functions **/
+
+  // Writes a joint target with id 'n' to the pre-amble section of a custom module
+  bool emitJointPosition(std::ostream& os, const TrajectoryPt& pt, size_t n);
+  // Writes a linear motion to joint target 'n'; the final parameters control special parameters for Wolf systems
+  bool emitGrindMotion(std::ostream& os, const ProcessParams& params, size_t n, bool start = false, bool end = false);
+  // Writes a free joint move to target 'n'
+  bool emitFreeMotion(std::ostream& os, const ProcessParams& params, size_t n, double duration, bool stop_at);
+  // Writes an I/O using the name from 'params'
+  bool emitSetOutput(std::ostream& os, const ProcessParams& params, size_t value);
+  // Writes the necessary info for process parameter blocks
+  bool emitProcessDeclarations(std::ostream& os, const ProcessParams& params, size_t value);
+}
+
+#endif

--- a/godel_robots/abb/abb_file_suite/rapid_generator/src/rapid_emitter.cpp
+++ b/godel_robots/abb/abb_file_suite/rapid_generator/src/rapid_emitter.cpp
@@ -1,0 +1,195 @@
+#include "rapid_generator/rapid_emitter.h"
+
+#include <iostream>
+
+bool rapid_emitter::emitRapidFile(std::ostream& os,
+                                  const std::vector<TrajectoryPt>& points,
+                                  size_t startProcessMotion,
+                                  size_t endProcessMotion,
+                                  const ProcessParams& params)
+{
+  // Write header
+  os << "MODULE mGodel_Blend\n\n";
+  // Emit all of the joint points
+  for (std::size_t i = 0; i < points.size(); ++i)
+  {
+    emitJointPosition(os, points[i], i);
+  }
+  // Emit Process Declarations
+  emitProcessDeclarations(os, params, 1);
+
+  // Write beginning of procedure
+  os << "\nPROC Godel_Blend()\n";
+  // For 0 to lengthFreeMotion, emit free moves
+  for (std::size_t i = 0; i < startProcessMotion; ++i)
+  {
+    if (i == 0) emitFreeMotion(os, params, i, 0.0, true);
+    else if (i == (startProcessMotion - 1)) emitFreeMotion(os, params, i, points[i].duration_, true);
+    else emitFreeMotion(os, params, i, points[i].duration_, false);
+  }
+  
+  // Turn on the tool
+  emitSetOutput(os, params, 1);
+  
+  // for lengthFreeMotion to end of points, emit grind moves
+  for (std::size_t i = startProcessMotion; i < endProcessMotion; ++i)
+  {
+    if (i == startProcessMotion)
+    {
+      emitGrindMotion(os, params, i, true, false);
+    }
+    else if (i == endProcessMotion-1)
+    {
+      emitGrindMotion(os, params, i, false, true);
+    }
+    else
+    {
+      emitGrindMotion(os, params, i);
+    }
+  }
+  
+  // Turn off the tool
+  emitSetOutput(os, params, 0);
+  
+  // for lengthFreeMotion to end of points, emit grind moves
+  for (std::size_t i = endProcessMotion; i < points.size(); ++i)
+  {
+    if (i == endProcessMotion) emitFreeMotion(os, params, i, 0.0, true);
+    else if (i == (points.size() - 1)) emitFreeMotion(os, params, i, points[i].duration_, true);
+    else emitFreeMotion(os, params, i, points[i].duration_, false);
+  }
+
+  os << "EndProc\n";
+
+  // write any footers including main procedure calling the above
+  os << "ENDMODULE\n";
+  return true;
+}
+
+
+bool rapid_emitter::emitGrindMotion(std::ostream& os, const ProcessParams& params, size_t n, bool start, bool end)
+{
+  // The 'fine' zoning means the robot will stop at this point
+
+  // Note that 'wolf_mode' indicates the presence of WolfWare software for the ABB which has
+  // a sepcial instruction called the 'GrindL'. This encapsulates both a robot motion and the
+  // state of a tool as it moves through the path. The 'Start' and 'End' varieties handle I/O.
+  if (params.wolf_mode)
+  {
+    if (start)
+    {
+      os << "GrindLStart CalcRobT(jTarget_" << n << ",tool0), v100, gr1, fine, tool0;\n";
+    }
+    else if (end)
+    {
+      os << "GrindLEnd CalcRobT(jTarget_" << n << ",tool0), v100, fine, tool0;\n";
+    }
+    else
+    {
+      os << "GrindL CalcRobT(jTarget_" << n << ",tool0), v100, z40, tool0;\n";
+    }
+  }
+  else
+  {
+    os << "MoveL CalcRobT(jTarget_" << n << ",tool0), vProcessSpeed, z5, tool0;\n";
+  }
+  return os.good();
+}
+
+bool rapid_emitter::emitFreeMotion(std::ostream& os, const ProcessParams& params, size_t n, double duration, bool stop_at)
+{
+  // We want the robot to move smoothly and stop at the last point; these tolerances ensure that this happens
+  const char* zone = stop_at ? "fine" : "z20";
+
+  if (duration <= 0.0)
+  {
+    os << "MoveJ CalcRobT(jTarget_" << n << ",tool0), vMotionSpeed," << zone << ", tool0;\n";
+  }
+  else
+  {  
+    os << "MoveJ CalcRobT(jTarget_" << n << ",tool0), vMotionSpeed, \\T:=" << duration << ", " << zone << ", tool0;\n";
+  }
+  return os.good();
+}
+bool rapid_emitter::emitJointPosition(std::ostream& os, const TrajectoryPt& pt, size_t n)
+{
+  os << "TASK PERS jointtarget jTarget_" << n << ":=[[";
+    for (size_t i = 0; i < pt.positions_.size() ; i++)
+    {
+      os << pt.positions_[i];
+      if (i < pt.positions_.size()-1)
+      {
+        os << ",";
+      }
+    }
+  // We assume a six axis robot here.
+  os << "],[9E9,9E9,9E9,9E9,9E9,9E9]];\n";
+  return true;
+}
+
+bool rapid_emitter::emitSetOutput(std::ostream& os, const ProcessParams& params, size_t value)
+{
+  // Wolf instructions handle I/O internally, so this method should do nothing
+  if (params.wolf_mode == false)
+  {
+    // This wait time is inserted here to ensure that the zone is achieved BEFORE the I/O happens
+    os << "WaitTime\\InPos, 0.01;\n";
+    os << "SETDO " << params.output_name << ", " << value << ";\n";
+   }
+  return os.good();
+} 
+
+bool rapid_emitter::emitProcessDeclarations(std::ostream& os, const ProcessParams& params, size_t value)
+{
+  if (params.wolf_mode)
+  {
+    os << "TASK PERS grinddata gr1:=[" << params.tcp_speed << "," << params.spindle_speed << "," << params.slide_force << ",FALSE,FALSE,FALSE,0,0];\n";
+  }
+  else
+  {
+    // Process Speed
+    os << "CONST speeddata vProcessSpeed:=[" << params.tcp_speed << "," << params.tcp_speed << ",50,50];\n";
+  }
+  // Free motion speed
+  os << "CONST speeddata vMotionSpeed:=[" << "200" << "," << "30" << ",500,500];\n";
+  return os.good();
+}
+
+
+bool rapid_emitter::emitJointTrajectoryFile(std::ostream &os, const std::vector<TrajectoryPt> &points, const ProcessParams &params)
+{
+  // Write header
+  os << "MODULE mGodel_Blend\n\n";
+  // Emit all of the joint points
+  for (std::size_t i = 0; i < points.size(); ++i)
+  {
+    emitJointPosition(os, points[i], i);
+  }
+  // Emit Process Declarations
+  emitProcessDeclarations(os, params, 1);
+  // Write beginning of procedure
+  os << "\nPROC Godel_Blend()\n";
+  // For 0 to lengthFreeMotion, emit free moves
+  if (points.empty())
+  {
+    return false;
+  }
+
+  // Write first point as normal move abs j so that the robot gets to where it needs to be
+  emitFreeMotion(os, params, 0, 0.0, true);
+
+  // The second motion 
+  for (std::size_t i = 1; i < points.size() - 1; ++i)
+  {
+    emitFreeMotion(os, params, i, points[i].duration_, false);
+  }
+
+  // Stop at the last point
+  emitFreeMotion(os, params, points.size() - 1, points.back().duration_, true);
+
+  os << "EndProc\n";
+  // write any footers including main procedure calling the above
+  os << "ENDMODULE\n";
+
+  return os.good();
+}

--- a/godel_robots/abb/abb_file_suite/src/abb_motion_ftp_downloader.cpp
+++ b/godel_robots/abb/abb_file_suite/src/abb_motion_ftp_downloader.cpp
@@ -1,0 +1,124 @@
+#include "abb_file_suite/abb_motion_ftp_downloader.h"
+
+#include <fstream>
+
+#include <ros/ros.h>
+
+#include "rapid_generator/rapid_emitter.h"
+#include "ftp_upload.h"
+
+// Constants
+const static std::string EXECUTE_PROGRAM_SERVICE_NAME = "execute_program";
+const static std::string RAPID_MODULE_NAME = "mGodel_blend.mod";
+
+// Utility functions
+static double toDegrees(const double radians)
+{ 
+  return radians * 180.0 / M_PI; 
+}
+
+static std::vector<double> toDegrees(const std::vector<double>& radians)
+{
+  std::vector<double> result;
+  result.reserve(radians.size());
+  for (std::size_t i = 0; i < radians.size(); ++i) result.push_back(toDegrees(radians[i]));
+  return result;
+}
+
+static void linkageAdjust(std::vector<double>& joints)
+{
+  joints[2] += joints[1];
+}
+
+/**
+ * Joins a directory and filename while being independent to whether the user
+ * added a trailing slash or not.
+ * 
+ * @param  dir      absolute path to directory
+ * @param  filename file name 
+ * @return          absolute path to file
+ */
+static std::string fileJoin(const std::string& dir, const std::string& filename)
+{
+  if (dir.back() == "/") return (dir + filename);
+  else return (dir + std::string("/") + filename);
+}
+
+abb_file_suite::AbbMotionFtpDownloader::AbbMotionFtpDownloader(const std::string &ip,
+                                                               const std::string &listen_topic,
+                                                               ros::NodeHandle &nh,
+                                                               bool j23_coupled,
+                                                               const std::string temp_file_loc)
+  : ip_(ip)
+  , temp_file_loc_(temp_file_loc)
+  , j23_coupled_(j23_coupled)
+{
+  trajectory_sub_ = nh.subscribe(
+        listen_topic,
+        10,
+        &AbbMotionFtpDownloader::handleJointTrajectory,
+        this);
+
+  server_ = nh.advertiseService(EXECUTE_PROGRAM_SERVICE_NAME, 
+                                &AbbMotionFtpDownloader::handleServiceCall, 
+                                this);
+}
+
+void abb_file_suite::AbbMotionFtpDownloader::handleJointTrajectory(const trajectory_msgs::JointTrajectory &traj)
+{
+  // Create temporary file
+  const std::string temp_file_path = fileJoin(temp_file_loc_, RAPID_MODULE_NAME);
+  // generate temporary file with appropriate rapid code
+  std::ofstream ofh (temp_file_path.c_str());
+
+  if (!ofh)
+  {
+    ROS_WARN_STREAM("Could not create file: " << temp_file_path);
+    return;
+  }
+
+  std::vector<rapid_emitter::TrajectoryPt> pts;
+  pts.reserve(traj.points.size());
+  for (std::size_t i = 0; i < traj.points.size(); ++i)
+  {
+    std::vector<double> tmp = toDegrees(traj.points[i].positions);
+    if (j23_coupled_) linkageAdjust(tmp);
+
+    double duration = 0.0;
+    // Timing
+    if (i > 0)
+    {
+      duration = (traj.points[i].time_from_start - traj.points[i-1].time_from_start).toSec(); 
+    }
+
+    rapid_emitter::TrajectoryPt pt (tmp, duration);
+    pts.push_back(pt);
+  }
+
+  rapid_emitter::ProcessParams params;
+  params.wolf = false;
+  rapid_emitter::emitJointTrajectoryFile(ofh, pts, params);
+  ofh.flush();
+  ofh.close();
+
+  // send to controller
+  if (!uploadFile(ip_ + "/PARTMODULES", temp_file_path))
+  {
+    ROS_WARN("Could not upload joint trajectory to remote ftp server");
+  }
+}
+
+bool abb_file_suite::AbbMotionFtpDownloader::handleServiceCall(abb_file_suite::ExecuteProgram::Request &req,
+                                                               abb_file_suite::ExecuteProgram::Response &res)
+{
+  // Check for existence
+  std::ifstream ifh (req.file_path.c_str());
+  if (!ifh)
+  {
+    ROS_WARN("Could not open file '%s'.", req.file_path.c_str());
+    return false;
+  }
+  ifh.close();
+
+  return uploadFile(ip_ + "/PARTMODULES", req.file_path.c_str());
+}

--- a/godel_robots/abb/abb_file_suite/src/abb_motion_ftp_downloader_node.cpp
+++ b/godel_robots/abb/abb_file_suite/src/abb_motion_ftp_downloader_node.cpp
@@ -1,0 +1,29 @@
+#include "abb_file_suite/abb_motion_ftp_downloader.h"
+#include <ros/ros.h>
+
+// This topic will work with ROS-I standard interfaces such as the action server
+// by default
+const static std::string DEFAULT_JOINT_LISTENING_TOPIC = "joint_path_command";
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "abb_motion_ftp_donwloader");
+
+  ros::NodeHandle nh, pnh("~");
+
+  // load parameters
+  std::string ip, topic;
+  bool j23_coupled;
+  pnh.param<std::string>("controller_ip", ip, "");
+  pnh.param<std::string>("topic", topic, DEFAULT_JOINT_LISTENING_TOPIC);
+  // Note this lookup is done using a non-private node handle. We assume we are looking up
+  // this parameter set in the launch file for many abb drivers.
+  nh.param<bool>("J23_coupled", j23_coupled, false);
+
+  abb_file_suite::AbbMotionFtpDownloader ftp(ip, topic, nh, j23_coupled);
+
+  ROS_INFO("ABB FTP-Trajectory-Downloader (ip %s) initialized. Listening on topic %s.", ip.c_str(), topic.c_str());
+  ros::spin();
+
+  return 0;
+}

--- a/godel_robots/abb/abb_file_suite/src/ftp_upload.cpp
+++ b/godel_robots/abb/abb_file_suite/src/ftp_upload.cpp
@@ -1,0 +1,147 @@
+#include "ftp_upload.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <curl/curl.h>
+
+/*
+ * The functions in this file are based on example software for libcurl
+ * including the ftpuploadresume.c example.
+ */
+
+const static long DEFAULT_TIMEOUT = 0; // Don't timeout
+const static long DEFAULT_RETRIES = 5;
+
+/* parse headers for Content-Length */
+static size_t getcontentlengthfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+  int r;
+  long len = 0;
+
+  /* _snscanf() is Win32 specific */
+  r = sscanf(static_cast<const char*>(ptr), "Content-Length: %ld\n", &len);
+
+  if (r) /* Microsoft: we don't read the specs */
+    *((long *) stream) = len;
+
+  return size * nmemb;
+}
+
+/* discard downloaded data */
+static size_t discardfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+  return size * nmemb;
+}
+
+/* read data to upload */
+static size_t readfunc(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+  FILE *f = static_cast<FILE*>(stream);
+  size_t n;
+
+  if (ferror(f))
+    return CURL_READFUNC_ABORT;
+
+  n = fread(ptr, size, nmemb, f) * size;
+
+  return n;
+}
+
+
+static int upload(CURL *curlhandle, const char * remotepath, const char * localpath,
+           long timeout, long tries)
+{
+  FILE *f;
+  long uploaded_len = 0;
+  CURLcode r = CURLE_GOT_NOTHING;
+  int c;
+
+  f = fopen(localpath, "rb");
+  if (f == NULL) {
+    perror(NULL);
+    return 0;
+  }
+
+  curl_easy_setopt(curlhandle, CURLOPT_UPLOAD, 1L);
+
+  curl_easy_setopt(curlhandle, CURLOPT_URL, remotepath);
+
+  curl_easy_setopt(curlhandle, CURLOPT_CONNECTTIMEOUT, 2L);
+
+  if (timeout)
+    curl_easy_setopt(curlhandle, CURLOPT_FTP_RESPONSE_TIMEOUT, timeout);
+
+  curl_easy_setopt(curlhandle, CURLOPT_HEADERFUNCTION, getcontentlengthfunc);
+  curl_easy_setopt(curlhandle, CURLOPT_HEADERDATA, &uploaded_len);
+
+  curl_easy_setopt(curlhandle, CURLOPT_WRITEFUNCTION, discardfunc);
+
+  curl_easy_setopt(curlhandle, CURLOPT_READFUNCTION, readfunc);
+  curl_easy_setopt(curlhandle, CURLOPT_READDATA, f);
+
+  curl_easy_setopt(curlhandle, CURLOPT_FTPPORT, "-"); /* disable passive mode */
+  curl_easy_setopt(curlhandle, CURLOPT_FTP_CREATE_MISSING_DIRS, 1L);
+
+  curl_easy_setopt(curlhandle, CURLOPT_VERBOSE, 1L);
+
+  for (c = 0; (r != CURLE_OK) && (c < tries); c++) {
+    /* are we resuming? */
+    if (c) { /* yes */
+      /* determine the length of the file already written */
+
+      /*
+       * With NOBODY and NOHEADER, libcurl will issue a SIZE
+       * command, but the only way to retrieve the result is
+       * to parse the returned Content-Length header. Thus,
+       * getcontentlengthfunc(). We need discardfunc() above
+       * because HEADER will dump the headers to stdout
+       * without it.
+       */
+      curl_easy_setopt(curlhandle, CURLOPT_NOBODY, 1L);
+      curl_easy_setopt(curlhandle, CURLOPT_HEADER, 1L);
+
+      r = curl_easy_perform(curlhandle);
+      if (r != CURLE_OK)
+        continue;
+
+      curl_easy_setopt(curlhandle, CURLOPT_NOBODY, 0L);
+      curl_easy_setopt(curlhandle, CURLOPT_HEADER, 0L);
+
+      fseek(f, uploaded_len, SEEK_SET);
+
+      curl_easy_setopt(curlhandle, CURLOPT_APPEND, 1L);
+    }
+    else { /* no */
+      curl_easy_setopt(curlhandle, CURLOPT_APPEND, 0L);
+    }
+
+    r = curl_easy_perform(curlhandle);
+  }
+
+  fclose(f);
+
+  if (r == CURLE_OK)
+    return 1;
+  else {
+    fprintf(stderr, "%s\n", curl_easy_strerror(r));
+    return 0;
+  }
+}
+
+bool abb_file_suite::uploadFile(const std::string &ftp_addr, const std::string &filepath)
+{
+  CURL *curlhandle = NULL;
+
+  curl_global_init(CURL_GLOBAL_ALL);
+  curlhandle = curl_easy_init();
+
+  std::string to = "ftp://" + ftp_addr + "/mGodelBlend.mod";
+
+  bool result = upload(curlhandle, to.c_str(), filepath.c_str(), DEFAULT_TIMEOUT, DEFAULT_RETRIES);
+
+  curl_easy_cleanup(curlhandle);
+  curl_global_cleanup();
+
+  return result;
+}

--- a/godel_robots/abb/abb_file_suite/src/ftp_upload.h
+++ b/godel_robots/abb/abb_file_suite/src/ftp_upload.h
@@ -1,0 +1,15 @@
+#ifndef FTP_UPLOAD_H
+#define FTP_UPLOAD_H
+
+#include <string>
+
+namespace abb_file_suite
+{
+
+bool uploadFile(const std::string& ftp_addr, const std::string& filepath);
+
+}
+
+
+#endif // FTP_UPLOAD_H
+

--- a/godel_robots/abb/abb_file_suite/srv/ExecuteProgram.srv
+++ b/godel_robots/abb/abb_file_suite/srv/ExecuteProgram.srv
@@ -1,0 +1,5 @@
+# Absolute file path to the RAPID file that will be uploaded to the Robot
+string file_path
+
+---
+# EMPTY - future improvements might inform of failure to establish connection


### PR DESCRIPTION
In the course of work on Godel's milestone 3, we had to run demos on a lot of ABB robots. The existing ABB driver is very limited in a few ways:
1. It is limited to downloading small trajectories
2. It suffers from pausing (an effect I assume is related to look-ahead issues)
3. There is no I/O support

To make the demos go, we created our own driver. This driver writes RAPID programs into a file, and then uploads that file directly to the robot using FTP. This is that driver.

The code is split into a library `rapid_generator`, that handles the file creation, and a ROS level interface that:
1. Handles standard ROS joint trajectories.
2. Allows users to upload arbitrary files through a service
