### PR TITLE
Path Execution Service

### DIFF
--- a/godel_path_execution/CMakeLists.txt
+++ b/godel_path_execution/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(godel_path_execution)
+
+find_package(catkin REQUIRED COMPONENTS
+  godel_msgs
+  roscpp
+  industrial_robot_simulator_service
+  actionlib
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+    actionlib
+    godel_msgs 
+    roscpp 
+    industrial_robot_simulator_service
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(path_execution_service_node 
+  src/path_execution_service_node.cpp 
+  src/path_execution_service.cpp
+)
+
+add_dependencies(path_execution_service_node godel_msgs_generate_messages_cpp)
+add_dependencies(path_execution_service_node industrial_robot_simulator_service_generate_messages_cpp)
+
+target_link_libraries(path_execution_service_node
+  ${catkin_LIBRARIES}
+)
+
+install(TARGETS path_execution_service_node
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/godel_path_execution/include/godel_path_execution/path_execution_service.h
+++ b/godel_path_execution/include/godel_path_execution/path_execution_service.h
@@ -1,0 +1,35 @@
+#ifndef PATH_EXECUTION_SERVICE_H
+#define PATH_EXECUTION_SERVICE_H
+
+#include <ros/ros.h>
+#include <godel_msgs/TrajectoryExecution.h>
+#include <actionlib/client/simple_action_client.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+
+namespace godel_path_execution
+{
+
+class PathExecutionService
+{
+public:
+  PathExecutionService(const std::string& name,
+                       const std::string& action_name,
+                       ros::NodeHandle& nh);
+
+  /**
+   * Currently forwards the godel_msgs::TrajectoryExecution on to the corresponding
+   * MoveIt node. The idea though is that abstracting 'execution' will give us more flexibility
+   * later to implement our own process parameters related to execution.
+   */
+  bool executionCallback(godel_msgs::TrajectoryExecution::Request& req,
+                         godel_msgs::TrajectoryExecution::Response& res);
+private:
+  ros::ServiceServer server_;
+  actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> ac_;
+  std::string name_;
+};
+
+}
+
+#endif // PATH_EXECUTION_SERVICE_H

--- a/godel_path_execution/launch/path_execution_service.launch
+++ b/godel_path_execution/launch/path_execution_service.launch
@@ -1,0 +1,8 @@
+<launch>
+  <!-- 
+  Features the following ROS interfaces: 
+    1.  motion action server : "joint_trajectory_action"
+    2.  this_service_name : "path_execution"
+  -->
+  <node pkg="godel_path_execution" type="path_execution_service_node" name="path_exection_service"/>
+</launch>

--- a/godel_path_execution/package.xml
+++ b/godel_path_execution/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<package>
+  <name>godel_path_execution</name>
+  <version>0.1.0</version>
+  <description>
+    This package manages the execution of joint trajectories
+    on the physical platform. Many components in Godel may
+    issue movement commands, and this package is envisioned
+    as a gate keeper of this motion. 
+  </description>
+
+  <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
+
+  <license>Apache 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>actionlib</build_depend>
+  <build_depend>godel_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>industrial_robot_simulator_service</build_depend>
+
+  <run_depend>actionlib</run_depend
+  ><run_depend>godel_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>industrial_robot_simulator_service</run_depend>
+
+</package>

--- a/godel_path_execution/src/path_execution_service.cpp
+++ b/godel_path_execution/src/path_execution_service.cpp
@@ -1,0 +1,63 @@
+#include <godel_path_execution/path_execution_service.h>
+#include <simulator_service/SimulateTrajectory.h>
+
+const static std::string ACTION_SERVER_NAME = "joint_trajectory_action";
+const static double ACTION_EXTRA_WAIT_RATIO = 0.2; // 20% past end of trajectory
+const static double ACTION_SERVICE_WAIT_TIME = 30.0; // seconds
+const static char* const ACTION_CONNECTION_FAILED_MSG = "Could not connect to action server.";
+
+const static std::string THIS_SERVICE_NAME = "path_execution";
+
+godel_path_execution::PathExecutionService::PathExecutionService(ros::NodeHandle& nh)
+  : ac_(ACTION_SERVER_NAME, true)
+{  
+  server_ = nh.advertiseService<PathExecutionService,
+                                godel_msgs::TrajectoryExecution::Request,
+                                godel_msgs::TrajectoryExecution::Response>
+            (THIS_SERVICE_NAME, &godel_path_execution::PathExecutionService::executionCallback, this);
+
+  // Attempt to connect to the motion action service
+  if (!ac_.waitForServer(ros::Duration(ACTION_SERVICE_WAIT_TIME)))
+  {
+    ROS_ERROR_STREAM(ACTION_CONNECTION_FAILED_MSG);
+    throw std::runtime_error(ACTION_CONNECTION_FAILED_MSG);
+  }
+}
+
+bool godel_path_execution::PathExecutionService::executionCallback(godel_msgs::TrajectoryExecution::Request& req,
+                                                                   godel_msgs::TrajectoryExecution::Response& res)
+{
+  // Check preconditions
+  if (!ac_.isServerConnected())
+  {
+    ROS_ERROR_STREAM("Action server is not connected.");
+    return false;
+  }
+
+  if (req.trajectory.points.empty()) 
+  {
+    ROS_WARN_STREAM("Trajectory Execution Service recieved an empty trajectory.");
+    return true;
+  }
+
+  // Populate goal and send
+  control_msgs::FollowJointTrajectoryGoal goal;
+  goal.trajectory = req.trajectory;
+  ac_.sendGoal(goal);
+
+  if (req.wait_for_execution)
+  {
+    ros::Duration extra_wait = goal.trajectory.points.back().time_from_start * ACTION_EXTRA_WAIT_RATIO;
+    if (ac_.waitForResult(goal.trajectory.points.back().time_from_start + extra_wait))
+    {
+      return ac_.getState().state_ == ac_.getState().SUCCEEDED;
+    }
+    else
+    {
+      ROS_ERROR_STREAM(__FUNCTION__ << ": Goal failed or did not complete in time.");
+      return false;
+    }
+  }
+
+  return true; // if we don't wait, then always return true immediately
+}

--- a/godel_path_execution/src/path_execution_service_node.cpp
+++ b/godel_path_execution/src/path_execution_service_node.cpp
@@ -1,0 +1,15 @@
+#include <godel_path_execution/path_execution_service.h>
+
+#include <ros/ros.h>
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "path_execution_service_node");
+
+  ros::NodeHandle nh;
+
+  godel_path_execution::PathExecutionService path_executor(nh);
+
+  ros::spin();
+  return 0;
+}


### PR DESCRIPTION
This package manages the execution of joint trajectories on the physical platform. Many components in Godel may issue movement commands, and this package is envisioned as a gate keeper of this motion.

It is a useful abstraction that allows us to change the underlying motion server as necessary without disrupting the many system components that rely on executing motions.
