### PR TITLE
Godel Process Path Generation

### DIFF
--- a/godel_process_path_generation/include/godel_process_path_generation/mesh_importer.h
+++ b/godel_process_path_generation/include/godel_process_path_generation/mesh_importer.h
@@ -75,7 +75,7 @@ private:
 
   bool applyConcaveHull(const Cloud& plane_cloud,pcl::ModelCoefficients &plane_coeffs,geometry_msgs::PolygonStamped& polygon);
 
-  void computeLocalPlaneFrame(const Eigen::Hyperplane<double, 3> &plane, const Eigen::Vector3d &centroid);
+  void computeLocalPlaneFrame(const Eigen::Hyperplane<double, 3> &plane, const Eigen::Vector4d &centroid, const Cloud& cloud);
 
   /**@brief Compute coefficients of a plane best fit to point cloud
    * Coefficients correspond to ax+by+cz+d=0

--- a/godel_process_path_generation/include/godel_process_path_generation/polygon_pts.hpp
+++ b/godel_process_path_generation/include/godel_process_path_generation/polygon_pts.hpp
@@ -58,7 +58,8 @@ struct PolygonPt
 
   friend ostream& operator<<(ostream &out, const PolygonPt &ppt);
 };
-ostream& operator<<(ostream &out, const PolygonPt &ppt)
+
+inline ostream& operator<<(ostream &out, const PolygonPt &ppt)
 {
   out << "(" << ppt.x << ", " << ppt.y << ")" << std::endl;
   return out;
@@ -67,7 +68,7 @@ ostream& operator<<(ostream &out, const PolygonPt &ppt)
 /**@brief A collection of polygon points that represent the boundary of a polygon.
  * Note: Last point assumed to join to 1st pt, not repeated in data. */
 typedef std::vector<PolygonPt> PolygonBoundary;
-ostream& operator<<(ostream &out, const PolygonBoundary &pb)
+inline ostream& operator<<(ostream &out, const PolygonBoundary &pb)
 {
   for (PolygonBoundary::const_iterator pt=pb.begin(), pt_end=pb.end(); pt != pt_end; ++pt)
   {
@@ -78,7 +79,7 @@ ostream& operator<<(ostream &out, const PolygonBoundary &pb)
 
 /**@brief A collection of polygonal boundaries that make up a complex shape */
 typedef std::vector<PolygonBoundary> PolygonBoundaryCollection;
-ostream& operator<<(ostream &out, const PolygonBoundaryCollection &pbc)
+inline ostream& operator<<(ostream &out, const PolygonBoundaryCollection &pbc)
 {
   size_t idx(0);
   for (PolygonBoundaryCollection::const_iterator pb=pbc.begin(), pb_end=pbc.end(); pb != pb_end; ++pb, ++idx)

--- a/godel_process_path_generation/include/godel_process_path_generation/polygon_utils.h
+++ b/godel_process_path_generation/include/godel_process_path_generation/polygon_utils.h
@@ -67,7 +67,7 @@ bool checkBoundary(const PolygonBoundary &bnd);
 bool checkBoundaryCollection(const PolygonBoundaryCollection &pbc);
 
 /**@brief calculate total length of boundary by summing segments */
-double circumference(const PolygonBoundary &boundary)
+inline double circumference(const PolygonBoundary &boundary)
 {
   double dist(0);      // Total distance squared
   for (PolygonBoundary::const_iterator pt=boundary.begin(); pt!=boost::prior(boundary.end()); ++pt)
@@ -97,7 +97,7 @@ void filter(PolygonBoundary &boundary, double tol);
  * @param boundaries PolygonBoundaryCollection to modify
  * @param tol allowable angle between adjacent segments to decide if edge is linear. If tol is outside [0, pi/2] it is reset to closest bound.
  */
-void filter(PolygonBoundaryCollection &boundaries, double tol)
+inline void filter(PolygonBoundaryCollection &boundaries, double tol)
 {
   // Check bounds of tol.
   if (tol > M_PI_2)

--- a/godel_process_path_generation/include/godel_process_path_generation/utils.h
+++ b/godel_process_path_generation/include/godel_process_path_generation/utils.h
@@ -51,7 +51,7 @@ namespace geometry
 {
 
 template <class Pt>
-std::vector<Pt> discretizeArc2D(const Pt &p1, const Pt &p2, const Pt &c, bool positive_rotation, double max_sep)
+inline std::vector<Pt> discretizeArc2D(const Pt &p1, const Pt &p2, const Pt &c, bool positive_rotation, double max_sep)
 {
   std::vector<Pt> vec;
   vec.push_back(p1);    // Add first point
@@ -88,7 +88,7 @@ std::vector<Pt> discretizeArc2D(const Pt &p1, const Pt &p2, const Pt &c, bool po
 }
 
 template <class Pt>
-std::vector<Pt> discretizeLinear(const Pt &p1, const Pt &p2, double max_sep)
+inline std::vector<Pt> discretizeLinear(const Pt &p1, const Pt &p2, double max_sep)
 {
   //add [start-end) with interpolated points between
   std::vector<Pt> vec;
@@ -116,7 +116,7 @@ namespace translations
  * @param polygons_msg vector of Polygons populated from PolygonBoundaryCollection. Z-value is unchanged.
  * @param pbc Collection of PolygonBoundaries.
  */
-void godelToGeometryMsgs(std::vector<geometry_msgs::Polygon> &polygons_msg, const godel_process_path::PolygonBoundaryCollection &pbc)
+inline void godelToGeometryMsgs(std::vector<geometry_msgs::Polygon> &polygons_msg, const godel_process_path::PolygonBoundaryCollection &pbc)
 {
   polygons_msg.clear();
   BOOST_FOREACH(::godel_process_path::PolygonBoundary polygon, pbc)
@@ -137,7 +137,7 @@ void godelToGeometryMsgs(std::vector<geometry_msgs::Polygon> &polygons_msg, cons
  * @param pbc Collection of PolygonBoundaries.
  * @param polygons_msg vector of Polygons populated from PolygonBoundaryCollection. Z-value is ignored.
  */
-void geometryMsgsToGodel(godel_process_path::PolygonBoundaryCollection &pbc, const std::vector<geometry_msgs::Polygon> &polygons_msg)
+inline void geometryMsgsToGodel(godel_process_path::PolygonBoundaryCollection &pbc, const std::vector<geometry_msgs::Polygon> &polygons_msg)
 {
   pbc.clear();
   BOOST_FOREACH(geometry_msgs::Polygon polygon_msg, polygons_msg)
@@ -160,7 +160,7 @@ void geometryMsgsToGodel(godel_process_path::PolygonBoundaryCollection &pbc, con
  * @param default_color Color to use for all points in marker.
  * @param default_scale Line width.
  */
-void godelToVisualizationMsgs(visualization_msgs::Marker &marker, const godel_process_path::PolygonBoundary &polygon,
+inline void godelToVisualizationMsgs(visualization_msgs::Marker &marker, const godel_process_path::PolygonBoundary &polygon,
                               std_msgs::ColorRGBA default_color = std_msgs::ColorRGBA(), double default_scale = .001)
 {
   marker.type = visualization_msgs::Marker::LINE_STRIP;
@@ -183,7 +183,7 @@ void godelToVisualizationMsgs(visualization_msgs::Marker &marker, const godel_pr
  * @param default_color Color to use for all points in all markers.
  * @param default_scale Line width for all markers.
  */
-void godelToVisualizationMsgs(visualization_msgs::MarkerArray &markers, const godel_process_path::PolygonBoundaryCollection &pbc,
+inline void godelToVisualizationMsgs(visualization_msgs::MarkerArray &markers, const godel_process_path::PolygonBoundaryCollection &pbc,
                               std_msgs::ColorRGBA default_color = std_msgs::ColorRGBA(), double default_scale = .001)
 {
   markers.markers.clear();
@@ -203,7 +203,7 @@ void godelToVisualizationMsgs(visualization_msgs::MarkerArray &markers, const go
  * @return True if item exists in container.
  */
 template <class Item, class Container>
-bool exists(const Item &item, const Container &container)
+inline bool exists(const Item &item, const Container &container)
 {
   return std::find(container.begin(), container.end(), item) != container.end();
 }
@@ -215,7 +215,7 @@ bool exists(const Item &item, const Container &container)
  * @return True if child found. If return is false, child left unchanged.
  */
 template <class Graph>
-bool getFirstChild(typename ::boost::graph_traits<Graph>::vertex_descriptor &child,
+inline bool getFirstChild(typename ::boost::graph_traits<Graph>::vertex_descriptor &child,
                    const typename ::boost::graph_traits<Graph>::vertex_descriptor &parent,
                    const Graph &g)
 {
@@ -237,7 +237,7 @@ bool getFirstChild(typename ::boost::graph_traits<Graph>::vertex_descriptor &chi
  * @return True if item moved successfully, false if "from" does not contain "iter"
  */
 template <class Container>
-bool moveIterFrom(Container &from, Container &to, typename Container::iterator iter)
+inline bool moveIterFrom(Container &from, Container &to, typename Container::iterator iter)
 {
   if (iter >= from.begin() && iter < from.end())
   {
@@ -256,7 +256,7 @@ bool moveIterFrom(Container &from, Container &to, typename Container::iterator i
  * @return True if item moved successfully, false if "from" does not contain "item"
  */
 template <class Container, class Item>
-bool moveItemFrom(Container &from, Container &to, const Item &item)
+inline bool moveItemFrom(Container &from, Container &to, const Item &item)
 {
   typename Container::iterator iter = std::find(from.begin(), from.end(), item);
   if (iter!=from.end())

--- a/godel_process_path_generation/src/mesh_importer.cpp
+++ b/godel_process_path_generation/src/mesh_importer.cpp
@@ -122,7 +122,7 @@ bool MeshImporter::calculateSimpleBoundary(const pcl::PolygonMesh &input_mesh)
 	  // computes local frame and saves it into the 'plane_frame_' member
 	  Eigen::Vector4d centroid4;
 	  pcl::compute3DCentroid(*points, centroid4);
-	  computeLocalPlaneFrame(hplane, centroid4.head(3));
+	  computeLocalPlaneFrame(hplane, centroid4, *points);
 	  if (verbose_)
 	  {
 	    ROS_INFO_STREAM("Local plane calculated with normal " << hplane.coeffs().transpose() << " and origin " << centroid4.transpose());
@@ -193,7 +193,7 @@ bool MeshImporter::calculateBoundaryData(const pcl::PolygonMesh &input_mesh)
 
   Eigen::Vector4d centroid4;
   pcl::compute3DCentroid(*points, centroid4);
-  computeLocalPlaneFrame(hplane, centroid4.head(3));
+  computeLocalPlaneFrame(hplane, centroid4, *points);
   if (verbose_)
   {
     ROS_INFO_STREAM("Local plane calculated with normal " << hplane.coeffs().transpose() << " and origin " << centroid4.transpose());
@@ -261,27 +261,29 @@ bool MeshImporter::calculateBoundaryData(const pcl::PolygonMesh &input_mesh)
   return true;
 }
 
-void MeshImporter::computeLocalPlaneFrame(const Eigen::Hyperplane<double, 3> &plane, const Vector3d &centroid)
+void MeshImporter::computeLocalPlaneFrame(const Eigen::Hyperplane<double, 3> &plane, const Vector4d &centroid, const Cloud& cloud)
 {
-  Eigen::Vector3d origin = plane.projection(centroid);       // Project centroid onto plane
+  Eigen::Vector3d origin = plane.projection(centroid.head<3>());       // Project centroid onto plane
+  const Eigen::Vector3d& plane_normal = plane.coeffs().head<3>();
+  // Compute major axis of the part
+  Eigen::Matrix3d covar_matrix;
+  pcl::computeCovarianceMatrixNormalized (cloud, centroid, covar_matrix);
+  // Find eigenvectors
+  Eigen::Matrix3d evecs;  // eigenvectors
+  Eigen::Vector3d evals; // eigenvalues
+  pcl::eigen33 (covar_matrix, evecs, evals);
+  // Y-axis can be estimated from the 2nd eigenvector
+  Eigen::Vector3d y_axis (evecs (0, 1), evecs (1, 1), evecs (2, 1));
+  y_axis = y_axis.normalized();
+  // Z-axis computed in plane segmentation step
+  Eigen::Vector3d z_axis (plane_normal.normalized());
+  // Cross product to obtain X axis
+  Eigen::Vector3d x_axis = y_axis.cross(z_axis);
 
-  // Check if z_axis (plane normal) is closely aligned with world x_axis:
-  // If not, construct transform rotation from X,Z axes. Otherwise, use Y,Z axes.
-  const Eigen::Vector3d& plane_normal = plane.coeffs().head(3);
-  if (std::abs(plane_normal.dot(Vector3d::UnitX())) < 0.8)
-  {
-    Eigen::Vector3d x_axis = plane.projection(origin + Eigen::Vector3d::UnitX())-origin;
-    plane_frame_.matrix().col(0).head(3) = x_axis.normalized();
-    plane_frame_.matrix().col(2).head(3) = plane_normal.normalized();
-    plane_frame_.matrix().col(1).head(3) = (plane_normal.normalized().cross(x_axis.normalized())).normalized();
-  }
-  else
-  {
-    Eigen::Vector3d y_axis = plane.projection(origin + Eigen::Vector3d::UnitY())-origin;
-    plane_frame_.matrix().col(1).head(3) = y_axis.normalized();
-    plane_frame_.matrix().col(2).head(3) = plane_normal.normalized();
-    plane_frame_.matrix().col(0).head(3) = (y_axis.normalized().cross(plane_normal.normalized())).normalized();
-  }
+  plane_frame_.matrix().col(0).head<3>() = x_axis;
+  plane_frame_.matrix().col(1).head<3>() = y_axis;
+  plane_frame_.matrix().col(2).head<3>() = z_axis;
+
   plane_frame_.translation() = origin;
 }
 


### PR DESCRIPTION
This PR adds a few changes to the process path generation routines that:
1. Fixes some compilation issues related to inline functions
2. Generates reference poses for surfaces that are oriented along the major axis of the surface
