### PR TITLE
Extrinsic Calibration Install Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,10 @@ Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C
   ```
   roslaunch godel_surface_detection kinect2.launch
   ```
+
+### Calibration
+This section contains instructions for performing extrinsic calibration of a camera (on the robot end effector) to the robot arm. This is only necessary if you are running on real hardware with the real sensor.
+
+- Extrinsic calibration routines depend on the [industrial_calibration](https://github.com/ros-industrial/industrial_calibration) package. Clone this package to your workspace.
+
+- The industrial calibration library builds against `libceres`, an optimization library, whose installation instructions are available [here](http://ceres-solver.org/building.html).

--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -6,3 +6,5 @@
     version: indigo-devel}
 - git: {local-name: motoman, uri: 'https://github.com/ros-industrial/motoman.git',
     version: indigo-devel}
+- git: {local-name: abb, uri: 'https://github.com/ros-industrial/abb.git',
+    version: indigo-devel}

--- a/godel_robots/godel_robot_resources/package.xml
+++ b/godel_robots/godel_robot_resources/package.xml
@@ -13,6 +13,4 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>industrial_extrinsic_cal</run_depend>
-
 </package>


### PR DESCRIPTION
Included with the recent Godel update are scripts for running the robot through an extrinsic calibration routine. This means there is a runtime depend on the industrial calibration package. This dependency caused the rosinstall step to fail.

I have elected to remove the dependency all together and to instead rely on a README section to instruct users how to build the calibration portion should they so desire. This was chosen to enable a smooth installation process for those just wanting to simulate a robot. The industrial calibration library requires some libraries to be installed from source.

Still missing are instructions for how to actually run the extrinsic calibration and update the files, but I will leave that for another day.
