### PR TITLE
Fix ignore entry for Moveit mongo dbs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ devel
 .cproject
 
 # mongodb instance
-*/default_warehouse_mongo_db/
+default_warehouse_mongo_db/


### PR DESCRIPTION
As per subject.

The `.gitignore` entry wasn't correct, resulting in mongo dbs not being ignored.
