### PR TITLE
Godel build instruction update for Kinetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,22 @@ Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C
 
 - Install [wstool](http://wiki.ros.org/wstool) in order manage the repos inside the workspace
   ```
-  sudo apt-get install python-wstool
+  sudo apt install python-wstool
   ```
 
 - Cd into the 'src' directory of your catkin workspace and run the following:
   ```
   wstool init . 
-  wstool merge https://github.com/ros-industrial-consortium/godel/raw/indigo-devel/godel.rosinstall
+  wstool merge https://github.com/ros-industrial-consortium/godel/raw/kinetic-devel/godel.rosinstall
   wstool update
   rosdep install --from-paths . --ignore-src
   cd ..
   catkin_make
+  ```
+
+- If you have issues regarding a missing `QD` library, then:
+  ```
+  sudo apt install libqd-dev
   ```
 
 ### Applications

--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,10 +1,16 @@
 - git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git',
-    version: indigo-devel}
+    version: kinetic-devel}
 - git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git',
     version: hydro-devel}
 - git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git',
-    version: indigo-devel}
+    version: kinetic-devel}
 - git: {local-name: motoman, uri: 'https://github.com/ros-industrial/motoman.git',
     version: indigo-devel}
-- git: {local-name: abb, uri: 'https://github.com/ros-industrial/abb.git',
-    version: indigo-devel}
+
+# Custom abb until Kinetic release happens
+- git: {local-name: abb, uri: 'https://github.com/Jmeyer1292/abb.git',
+    version: kinetic-devel}
+
+# Custom industrial core until a Kinetic release happens
+- git: {local-name: industrial_core, uri: 'https://github.com/Jmeyer1292/industrial_core.git',
+    version: kinetic-devel}

--- a/godel_process_planning/CMakeLists.txt
+++ b/godel_process_planning/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(godel_process_planning)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   descartes_core
   descartes_moveit

--- a/godel_robots/abb/godel_irb2400/abb_irb2400_descartes/CMakeLists.txt
+++ b/godel_robots/abb/godel_irb2400/abb_irb2400_descartes/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(abb_irb2400_descartes)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   descartes_core
   descartes_moveit


### PR DESCRIPTION
This will get people up and running more quickly.

Until we get releases of `industrial_core` and `abb`, I created my own that just add the appropriate c++11 flags.

@woodaaron @gavanderhoorn please review.