### PR TITLE
Default Scan Position Changed to Reachable Position

### DIFF
--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/config/robot_scan.yaml
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/config/robot_scan.yaml
@@ -15,7 +15,7 @@ robot_scan:
       w: 1
   world_to_obj_pose:
     trans:
-      x: 1.0
+      x: 0.5
       y: 0.0
       z: 0.5
     quat:


### PR DESCRIPTION
The default scan parameters for the abb2400 demo are set too far forward in the X direction for the robot to actually reach. This PR moves that a 0.5m backward.

This means that people can download our software, build the demo, and it just works...

@AustinDeric would you please review?