### PR TITLE
ROS-Install Modifications

### DIFF
--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,5 +1,5 @@
 - git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git',
-    version: indigo-devel}
+    version: kinetic-devel}
 - git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git',
     version: hydro-devel}
 - git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git',

--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,7 +1,7 @@
 - git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git',
     version: indigo-devel}
-- git: {local-name: godel_openvoronoi, uri: 'https://github.com/Jmeyer1292/godel_openvoronoi',
-    version: fix/alternate_symlinks}
+- git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git',
+    version: hydro-devel}
 - git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git',
     version: kinetic-devel}
 - git: {local-name: motoman, uri: 'https://github.com/ros-industrial/motoman.git',


### PR DESCRIPTION
Small changes that:
 - Point `godel_openvoronoi` back toward the ros-industrial version since its been fixed to work with Travis.
 - Points `descartes` toward the kinetic devel version.