### PR TITLE
Removes Explicit Dependency on PCL 1.7

### DIFF
--- a/godel_process_path_generation/CMakeLists.txt
+++ b/godel_process_path_generation/CMakeLists.txt
@@ -20,8 +20,6 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(Boost REQUIRED COMPONENTS system)
-find_package(PCL 1.7 REQUIRED QUIET)
-#find_package(PCL 1.7.2 EXACT REQUIRED QUIET)
 find_package(Eigen REQUIRED)
 
 ## Generate services in the 'srv' folder


### PR DESCRIPTION
This package depends on an exact version of PCL and also on `pcl_ros`. If we upgrade pcl_ros to point to PCL 1.8, then we run into conflicts between library versions where this library and others depend on both PCL 1.8 and 1.7.

This PR simply removes that. A quick check with `ldd` shows that 1.7 issue goes away after a clean rebuild.
