### PR TITLE
Glyph Load Segfault Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,3 @@ This section contains instructions for performing extrinsic calibration of a cam
 - Extrinsic calibration routines depend on the [industrial_calibration](https://github.com/ros-industrial/industrial_calibration) package. Clone this package to your workspace.
 
 - The industrial calibration library builds against `libceres`, an optimization library, whose installation instructions are available [here](http://ceres-solver.org/building.html).
-
-### Qt Glyph Loading Segfault (Kinetic)
-Rviz on Kinetic is prone to a segmentation fault caused by internal functions in the Qt library. Our current work-around is to set the following environment variable:
-  ```
-  export QT_NO_FT_CACHE=1
-  ```

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/config/env-loader.sh
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/config/env-loader.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+export QT_NO_FT_CACHE=1
+exec "$@"

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
@@ -60,12 +60,12 @@
   </group>
   
   <group if="$(arg debug_mode)">
-    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_irb2400_support)/rviz/irb2400_blending.rviz" output="screen" launch-prefix="xterm -e gdb --args" required="true"/>
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_irb2400_support)/rviz/irb2400_blending.rviz" output="screen" launch-prefix="xterm -e gdb --args" required="true" env_loader="$(find godel_irb2400_support)/config/env-loader.sh"/>
   </group>
 
   <!-- rviz w/ specified configuration -->
   <group unless="$(arg debug_mode)">
-    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_irb2400_support)/rviz/irb2400_blending.rviz" output="screen" launch-prefix="nice" required="true"/>
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_irb2400_support)/rviz/irb2400_blending.rviz" output="screen" launch-prefix="nice" required="true" env_loader="$(find godel_irb2400_support)/config/env-loader.sh"/>
   </group>
 
   <!-- Bring up the MoveIt interface to the real or simulated robot -->


### PR DESCRIPTION
Per discussion in #141, uses an env-loader tag to set the QT_NO_FT_CACHE variable in the irb2400_blending launch file. The loading script is minimalistic; it simply sets the environment variable and executes.

Readme updated to remove workaround directions.