### PR TITLE
Multi-Segment Process Paths

### DIFF
--- a/godel_msgs/msg/ProcessPath.msg
+++ b/godel_msgs/msg/ProcessPath.msg
@@ -1,3 +1,9 @@
 # ProcessPath
 
-geometry_msgs/PoseArray poses
+# The frame of reference for poses is assumed to be the root of the
+# workspace as specified in the URDF
+
+# The process path consists of some number of 'pose sequences' each of which
+# represents a segment of the path in which the tool constraints must be held.
+# In between segments, the tool can 'retract' and the robot can change config.
+geometry_msgs/PoseArray[] segments

--- a/godel_process_planning/CMakeLists.txt
+++ b/godel_process_planning/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(godel_process_planning_node
   src/godel_process_planning_node.cpp
   src/keyence_process_planning.cpp
   src/trajectory_utils.cpp
+  src/generate_motion_plan.cpp
 )
 
 ## Add cmake target dependencies of the executable/library

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -8,6 +8,7 @@
 #include "descartes_planner/dense_planner.h"
 
 #include "common_utils.h"
+#include "generate_motion_plan.h"
 #include "eigen_conversions/eigen_msg.h"
 #include "boost/make_shared.hpp"
 
@@ -18,17 +19,9 @@ namespace godel_process_planning
 const double BLENDING_ANGLE_DISCRETIZATION =
     M_PI / 12.0; // The discretization of the tool's pose about
                  // the z axis
-const double FREE_SPACE_MAX_ANGLE_DELTA =
-    M_PI_2; // The maximum angle a joint during a freespace motion
-            // from the start to end position without that motion
-            // being penalized. Avoids flips.
-const double FREE_SPACE_ANGLE_PENALTY =
-    5.0; // The factor by which a joint motion is multiplied if said
-         // motion is greater than the max.
 const static std::string JOINT_TOPIC_NAME =
     "joint_states"; // ROS topic to subscribe to for current robot
                     // state info
-
 /**
  * @brief Translated an Eigen pose to a Descartes trajectory point appropriate for the BLEND
  * process!
@@ -47,65 +40,6 @@ static inline descartes_core::TrajectoryPtPtr toDescartesPt(const Eigen::Affine3
                                               AxialSymmetricPt::Z_AXIS, tm);
 }
 
-/**
- * @brief Computes a 'cost' value for a robot motion between 'source' and 'target'
- * @param source  The joint configuration at start of motion
- * @param target  The joint configuration at end of motion
- * @return cost value
- */
-double freeSpaceCostFunctionBlending(const std::vector<double>& source,
-                                     const std::vector<double>& target)
-{
-  // The cost function here penalizes large single joint motions in an effort to
-  // keep the robot from flipping a joint, even if some other joints have to move
-  // a bit more.
-  double cost = 0.0;
-  for (std::size_t i = 0; i < source.size(); ++i)
-  {
-    double diff = std::abs(source[i] - target[i]);
-    if (diff > FREE_SPACE_MAX_ANGLE_DELTA)
-      cost += FREE_SPACE_ANGLE_PENALTY * diff;
-    else
-      cost += diff;
-  }
-  return cost;
-}
-
-/**
- * @brief transforms an input, in the form of a reference pose and points relative to that pose,
- * into Descartes'
- *        native format. Also adds in associated parameters.
- * @param ref The reference posed that all points are multiplied by. Should be in the world space of
- * the blend move group.
- * @param points Sequence of points (relative to ref and the world space of blending robot model)
- * @param params Surface blending parameters, including info such as traversal speed
- * @return The input trajectory encoded in Descartes points
- */
-static godel_process_planning::DescartesTraj
-toDescartesTraj(const geometry_msgs::Pose& ref, const std::vector<geometry_msgs::Point>& points,
-                const godel_msgs::BlendingPlanParameters& params)
-{
-  DescartesTraj traj;
-  traj.reserve(points.size());
-  if (points.empty())
-    return traj;
-
-  Eigen::Affine3d last_pose = createNominalTransform(ref, points.front());
-
-  for (std::size_t i = 0; i < points.size(); ++i)
-  {
-    Eigen::Affine3d this_pose = createNominalTransform(ref, points[i]);
-    // O(1) jerky - may need to revisit this time parameterization later. This at least allows
-    // Descartes to perform some optimizations in its graph serach.
-    double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
-    traj.push_back(toDescartesPt(this_pose, dt));
-    last_pose = this_pose;
-  }
-
-  return traj;
-}
-
-
 static EigenSTL::vector_Affine3d linearMoveZ(const Eigen::Affine3d& origin, double step_size, int steps)
 {
   EigenSTL::vector_Affine3d result (steps);
@@ -117,6 +51,8 @@ static EigenSTL::vector_Affine3d linearMoveZ(const Eigen::Affine3d& origin, doub
 
   return result;
 }
+
+
 
 /**
  * @brief toDescartesTraj
@@ -132,7 +68,7 @@ toDescartesTraj(const std::vector<geometry_msgs::PoseArray>& segments,
 
   const static double step_size = 0.02; // m
 
-  int steps = std::round(params.safe_traverse_height / step_size);
+  int steps = std::ceil(params.safe_traverse_height / step_size);
 
   // Loop over every connecting edge
   for (std::size_t i = 1; i < segments.size(); ++i)
@@ -233,117 +169,19 @@ bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlannin
     }
   }
 
-
   // Transform process path from geometry msgs to descartes points
-  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params);
-
-  // Capture the current state of the robot
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
 
-  // Compute all of the joint poses at the start of the process path
-  std::vector<std::vector<double> > start_joint_poses;
-  process_points.front()->getJointPoses(*blend_model_, start_joint_poses);
+  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params);
 
-  if (start_joint_poses.empty())
+  if (generateMotionPlan(blend_model_, process_points, moveit_model_, blend_group_name_,
+                         current_joints, res.plan))
   {
-    ROS_WARN_STREAM("Blend Planning Service: Could not compute any inverse kinematic solutions for "
-                    "the first point in the process path.");
-
-    return false;
-  }
-
-  ROS_INFO_STREAM("Number of candidate poses: " << start_joint_poses.size());
-
-  auto start_pose = godel_process_planning::pickBestStartPose(current_joints, *blend_model_, start_joint_poses, freeSpaceCostFunctionBlending);
-
-  DescartesTraj solved_path;
-  // Calculate tool pose of robot starting config so that we can go back here on the
-  // return move
-  Eigen::Affine3d init_pose;
-  blend_model_->getFK(current_joints, init_pose);
-  // Compute the nominal tool pose of the final process point
-  Eigen::Affine3d process_stop_pose;
-  process_points.back()->getNominalCartPose(std::vector<double>(), *blend_model_,
-                                            process_stop_pose);
-
-  // Joint interpolate from the initial robot position to 'best' starting configuration of process
-  // path
-  DescartesTraj to_process = createJointPath(current_joints, start_pose);
-  to_process.front() =
-      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
-
-  // To get a rough estimate of process path cost, add a cartesian move from the final process point
-  // to the starting position again.
-  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
-  from_process.back() =
-      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
-
-  // Affix the approach and depart paths calculated above with user process path
-  DescartesTraj seed_path;
-  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
-  seed_path.insert(seed_path.end(), process_points.begin(), process_points.end());
-  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
-
-  // Attempt to solve the initial path (minimize joint motion over entire plan)
-  if (!descartesSolve(seed_path, blend_model_, solved_path))
-  {
-    return false;
-  }
-
-  // Go back over and recalculate the approach and depart segments to:
-  //  1. Use a joint interpolation from start to stop if collision free
-  //  2. Use MoveIt (RRT-Connect) if the above fails
-  // This is the only portion of the trajectory that is collision checked. Note this
-  // method also converts the Descartes points into ROS trajectories.
-  try
-  {
-    trajectory_msgs::JointTrajectory approach =
-        planFreeMove(*blend_model_, blend_group_name_, moveit_model_,
-                     extractJoints(*blend_model_, *solved_path[0]),
-                     extractJoints(*blend_model_, *solved_path[to_process.size()]));
-
-    trajectory_msgs::JointTrajectory depart = planFreeMove(
-        *blend_model_, blend_group_name_, moveit_model_,
-        extractJoints(*blend_model_, *solved_path[to_process.size() + process_points.size() - 1]),
-        extractJoints(*blend_model_, *solved_path[seed_path.size() - 1]));
-
-    // Break out the process path from the seed path and convert to ROS messages
-    DescartesTraj process_part(solved_path.begin() + to_process.size(),
-                               solved_path.end() - from_process.size());
-    trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *blend_model_);
-
-    for (std::size_t i = 0; i < process.points.size(); ++i)
-    {
-      const auto& pt = process.points[i];
-      if (!blend_model_->isValid(pt.positions))
-      {
-        ROS_WARN_STREAM("Position in blending path (" << i << ") invalid: Joint limit or collision detected\n");
-        return false;
-      }
-    }
-
-
-    // Fill in result trajectories
-    res.plan.trajectory_process = process;
-    res.plan.trajectory_approach = approach;
-    res.plan.trajectory_depart = depart;
-
-    // Fill in result header information
-    const std::vector<std::string>& joint_names =
-        moveit_model_->getJointModelGroup(blend_group_name_)->getActiveJointModelNames();
-
-    godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_approach);
-    godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_depart);
-    godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_process);
-
-    // set the type to blend plan
-    res.plan.type = godel_msgs::ProcessPlan::BLEND_TYPE;
-
+    res.plan.type = res.plan.BLEND_TYPE;
     return true;
   }
-  catch (const std::runtime_error& e)
+  else
   {
-    ROS_ERROR_STREAM("Exception caught when planning blending path: " << e.what());
     return false;
   }
 }

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -8,6 +8,7 @@
 #include "descartes_planner/dense_planner.h"
 
 #include "common_utils.h"
+#include "eigen_conversions/eigen_msg.h"
 #include "boost/make_shared.hpp"
 
 namespace godel_process_planning
@@ -104,33 +105,100 @@ toDescartesTraj(const geometry_msgs::Pose& ref, const std::vector<geometry_msgs:
   return traj;
 }
 
+
+static EigenSTL::vector_Affine3d linearMoveZ(const Eigen::Affine3d& origin, double step_size, int steps)
+{
+  EigenSTL::vector_Affine3d result (steps);
+
+  for (int i = 0; i < steps; ++i)
+  {
+    result[i] = origin * Eigen::Translation3d(0, 0, step_size * (i + 1));
+  }
+
+  return result;
+}
+
 /**
- * @brief transforms an input, in the form of a pose array relative to that pose,
- * into Descartes' native format. Also adds in associated parameters.
- * @param poses Sequence of poses (relative to the world space of blending robot model)
- * @param params Surface blending parameters, including info such as traversal speed
- * @return The input trajectory encoded in Descartes points
+ * @brief toDescartesTraj
+ * @param poses
+ * @param params
+ * @return
  */
 static godel_process_planning::DescartesTraj
-toDescartesTraj(const geometry_msgs::PoseArray& poses,
+toDescartesTraj(const std::vector<geometry_msgs::PoseArray>& segments,
                 const godel_msgs::BlendingPlanParameters& params)
 {
-  DescartesTraj traj;
-  traj.reserve(poses.poses.size());
-  if (poses.poses.empty())
-    return traj;
+  std::vector<EigenSTL::vector_Affine3d> connections;
 
-  Eigen::Affine3d last_pose = createNominalTransform(poses.poses.front());
+  const static double step_size = 0.02; // m
 
-  for (std::size_t i = 0; i < poses.poses.size(); ++i)
+  int steps = std::round(params.safe_traverse_height / step_size);
+
+  // Loop over every connecting edge
+  for (std::size_t i = 1; i < segments.size(); ++i)
   {
-    Eigen::Affine3d this_pose = createNominalTransform(poses.poses[i]);
-    // O(1) jerky - may need to revisit this time parameterization later. This at least allows
-    // Descartes to perform some optimizations in its graph serach.
-    double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
-    traj.push_back(toDescartesPt(this_pose, dt));
-    last_pose = this_pose;
+    const auto& from_pose = segments[i - 1].poses.back(); // Where we come from...
+    const auto& to_pose = segments[i].poses.front();      // Where we want to end up
+
+    Eigen::Affine3d e_from, e_to;
+    tf::poseMsgToEigen(from_pose, e_from);
+    tf::poseMsgToEigen(to_pose, e_to);
+
+    // Each connecting segment has a retraction from 'from_pose'
+    // And an approach to 'to_pose'
+    auto from = linearMoveZ(e_from, step_size, steps);
+    auto to = linearMoveZ(e_to, step_size, steps);
+    std::reverse(to.begin(), to.end()); // we flip the 'to' path to keep the time ordering of the path
+
+    connections.push_back(from);
+    connections.push_back(to);
   }
+
+  DescartesTraj traj;
+  Eigen::Affine3d last_pose = createNominalTransform(segments.front().poses.front());
+
+  for (std::size_t i = 0; i < segments.size(); ++i)
+  {
+    // Create Descartes trajectory for the segment path
+    for (std::size_t j = 0; j < segments[i].poses.size(); ++j)
+    {
+      Eigen::Affine3d this_pose = createNominalTransform(segments[i].poses[j]);
+      // O(1) jerky - may need to revisit this time parameterization later. This at least allows
+      // Descartes to perform some optimizations in its graph serach.
+      double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
+      traj.push_back(toDescartesPt(this_pose, dt));
+      last_pose = this_pose;
+    }
+
+    // If we're not on the last segment, then we have connections to add
+    if (i != segments.size() - 1)
+    {
+      const auto& depart = connections[i * 2 + 0];
+      const auto& approach = connections[i * 2 + 1];
+
+      // Create Descartes trajectory for the departure path
+      for (std::size_t j = 0; j < depart.size(); ++j)
+      {
+        Eigen::Affine3d this_pose = createNominalTransform(depart[j]);
+        // O(1) jerky - may need to revisit this time parameterization later. This at least allows
+        // Descartes to perform some optimizations in its graph serach.
+        double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
+        traj.push_back(toDescartesPt(this_pose, dt));
+        last_pose = this_pose;
+      }
+
+      for (std::size_t j = 0; j < approach.size(); ++j)
+      {
+        Eigen::Affine3d this_pose = createNominalTransform(approach[j]);
+        // O(1) jerky - may need to revisit this time parameterization later. This at least allows
+        // Descartes to perform some optimizations in its graph serach.
+        double dt =
+            j == 0 ? 0.0 : (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
+        traj.push_back(toDescartesPt(this_pose, dt));
+        last_pose = this_pose;
+      }
+    } // end connections
+  } // end segments
 
   return traj;
 }
@@ -145,18 +213,29 @@ toDescartesTraj(const geometry_msgs::PoseArray& poses,
 bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlanning::Request& req,
                                                  godel_msgs::BlendProcessPlanning::Response& res)
 {
-  // Precondition: Input trajectory must be non-zero
-  if (req.path.poses.poses.empty())
-  {
-    ROS_WARN("%s: Cannot create blend process plan for empty trajectory", __FUNCTION__);
-    return false;
-  }
-
   // Enable Collision Checks
   blend_model_->setCheckCollisions(true);
 
+  // Precondition: There must be at least one input segments
+  if (req.path.segments.empty())
+  {
+    ROS_WARN("Planning request contained no trajectory segments. Nothing to be done.");
+    return false;
+  }
+
+  // Precondition: All input segments must have at least one pose associated with them
+  for (const auto& segment : req.path.segments)
+  {
+    if (segment.poses.empty())
+    {
+      ROS_WARN("Input trajectory segment contained no poses. Invalid input.");
+      return false;
+    }
+  }
+
+
   // Transform process path from geometry msgs to descartes points
-  DescartesTraj process_points = toDescartesTraj(req.path.poses, req.params);
+  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params);
 
   // Capture the current state of the robot
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);

--- a/godel_process_planning/src/common_utils.cpp
+++ b/godel_process_planning/src/common_utils.cpp
@@ -307,3 +307,29 @@ godel_process_planning::filterColliding(descartes_core::RobotModel& model,
   return results;
 }
 
+
+double godel_process_planning::freeSpaceCostFunction(const std::vector<double> &source,
+                                                     const std::vector<double> &target)
+{
+  const double FREE_SPACE_MAX_ANGLE_DELTA =
+      M_PI_2; // The maximum angle a joint during a freespace motion
+              // from the start to end position without that motion
+              // being penalized. Avoids flips.
+  const double FREE_SPACE_ANGLE_PENALTY =
+      5.0; // The factor by which a joint motion is multiplied if said
+           // motion is greater than the max.
+
+  // The cost function here penalizes large single joint motions in an effort to
+  // keep the robot from flipping a joint, even if some other joints have to move
+  // a bit more.
+  double cost = 0.0;
+  for (std::size_t i = 0; i < source.size(); ++i)
+  {
+    double diff = std::abs(source[i] - target[i]);
+    if (diff > FREE_SPACE_MAX_ANGLE_DELTA)
+      cost += FREE_SPACE_ANGLE_PENALTY * diff;
+    else
+      cost += diff;
+  }
+  return cost;
+}

--- a/godel_process_planning/src/common_utils.cpp
+++ b/godel_process_planning/src/common_utils.cpp
@@ -64,6 +64,15 @@ Eigen::Affine3d godel_process_planning::createNominalTransform(const geometry_ms
   return eigen_pose * flip_z;
 }
 
+Eigen::Affine3d godel_process_planning::createNominalTransform(const Eigen::Affine3d &ref_pose)
+{
+  // Reverse the Z axis
+  Eigen::Affine3d flip_z;
+  flip_z = Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitY());
+
+  return ref_pose * flip_z;
+}
+
 bool godel_process_planning::descartesSolve(const godel_process_planning::DescartesTraj& in_path,
                                             descartes_core::RobotModelConstPtr robot_model,
                                             godel_process_planning::DescartesTraj& out_path)
@@ -268,3 +277,4 @@ godel_process_planning::filterColliding(descartes_core::RobotModel& model,
   }
   return results;
 }
+

--- a/godel_process_planning/src/common_utils.cpp
+++ b/godel_process_planning/src/common_utils.cpp
@@ -58,11 +58,7 @@ Eigen::Affine3d godel_process_planning::createNominalTransform(const geometry_ms
 
   tf::poseMsgToEigen(ref_pose, eigen_pose);
 
-  // Reverse the Z axis
-  Eigen::Affine3d flip_z;
-  flip_z = Eigen::AngleAxisd(M_PI, Eigen::Vector3d::UnitY());
-
-  return eigen_pose * flip_z;
+  return createNominalTransform(eigen_pose);
 }
 
 Eigen::Affine3d godel_process_planning::createNominalTransform(const Eigen::Affine3d &ref_pose)

--- a/godel_process_planning/src/common_utils.h
+++ b/godel_process_planning/src/common_utils.h
@@ -32,6 +32,9 @@ Eigen::Affine3d createNominalTransform(const geometry_msgs::Pose& ref_pose,
    */
 Eigen::Affine3d createNominalTransform(const geometry_msgs::Pose& ref_pose);
 
+
+Eigen::Affine3d createNominalTransform(const Eigen::Affine3d& ref_pose);
+
 /**
  * @brief Given a path and robot model, this method creates a descartes planner and attempts to
  * solve the path

--- a/godel_process_planning/src/common_utils.h
+++ b/godel_process_planning/src/common_utils.h
@@ -157,7 +157,14 @@ inline std::vector<double> pickBestStartPose(const std::vector<double>& start,
 {
   // step 1: Filter out candidates that are already in collision
   auto not_colliding = godel_process_planning::filterColliding(model, candidates);
-  ROS_WARN("After filtering: %lu", not_colliding.size());
+
+  if (not_colliding.empty())
+  {
+    ROS_WARN("After filtering %lu possible process start poses, all were found"
+             " to be in collision.", candidates.size());
+    throw std::runtime_error("No valid starting poses");
+  }
+
   // step 2: sort them by "closeness" cost
   std::sort(not_colliding.begin(), not_colliding.end(), [&start, cost_func]
             (const std::vector<double>& a, const std::vector<double>& b) {
@@ -165,11 +172,6 @@ inline std::vector<double> pickBestStartPose(const std::vector<double>& start,
     auto b_cost = cost_func(start, b);
     return a_cost < b_cost;
   });
-
-  if (not_colliding.empty())
-  {
-    throw std::runtime_error("No valid starting poses");
-  }
 
   return not_colliding.front();
 }

--- a/godel_process_planning/src/generate_motion_plan.cpp
+++ b/godel_process_planning/src/generate_motion_plan.cpp
@@ -1,0 +1,117 @@
+#include "generate_motion_plan.h"
+#include "common_utils.h"
+#include <descartes_trajectory/axial_symmetric_pt.h>
+#include <descartes_trajectory/joint_trajectory_pt.h>
+
+bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModelPtr model,
+                                                const std::vector<descartes_core::TrajectoryPtPtr> &traj,
+                                                moveit::core::RobotModelConstPtr moveit_model,
+                                                const std::string &move_group_name,
+                                                const std::vector<double> &start_state,
+                                                godel_msgs::ProcessPlan &plan)
+{
+  // Compute all of the joint poses at the start of the process path
+  std::vector<std::vector<double> > start_joint_poses;
+  traj.front()->getJointPoses(*model, start_joint_poses);
+
+  if (start_joint_poses.empty())
+  {
+    ROS_WARN_STREAM("Blend Planning Service: Could not compute any inverse kinematic solutions for "
+                    "the first point in the process path.");
+
+    return false;
+  }
+
+  ROS_INFO_STREAM("Number of candidate poses: " << start_joint_poses.size());
+
+  auto start_pose = godel_process_planning::pickBestStartPose(start_state, *model,
+                                                              start_joint_poses,
+                                                              freeSpaceCostFunction);
+
+  DescartesTraj solved_path;
+  // Calculate tool pose of robot starting config so that we can go back here on the
+  // return move
+  Eigen::Affine3d init_pose;
+  model->getFK(start_state, init_pose);
+  // Compute the nominal tool pose of the final process point
+  Eigen::Affine3d process_stop_pose;
+  traj.back()->getNominalCartPose(std::vector<double>(), *model,
+                                  process_stop_pose);
+
+  // Joint interpolate from the initial robot position to 'best' starting configuration of process
+  // path
+  DescartesTraj to_process = createJointPath(start_state, start_pose);
+  to_process.front() =
+      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
+
+  // To get a rough estimate of process path cost, add a cartesian move from the final process point
+  // to the starting position again.
+  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
+  from_process.back() =
+      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
+
+  // Affix the approach and depart paths calculated above with user process path
+  DescartesTraj seed_path;
+  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
+  seed_path.insert(seed_path.end(), traj.begin(), traj.end());
+  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
+
+  // Attempt to solve the initial path (minimize joint motion over entire plan)
+  if (!descartesSolve(seed_path, model, solved_path))
+  {
+    return false;
+  }
+
+  // Go back over and recalculate the approach and depart segments to:
+  //  1. Use a joint interpolation from start to stop if collision free
+  //  2. Use MoveIt (RRT-Connect) if the above fails
+  // This is the only portion of the trajectory that is collision checked. Note this
+  // method also converts the Descartes points into ROS trajectories.
+  try
+  {
+    trajectory_msgs::JointTrajectory approach =
+        planFreeMove(*model, move_group_name, moveit_model,
+                     extractJoints(*model, *solved_path[0]),
+                     extractJoints(*model, *solved_path[to_process.size()]));
+
+    trajectory_msgs::JointTrajectory depart = planFreeMove(
+        *model, move_group_name, moveit_model,
+        extractJoints(*model, *solved_path[to_process.size() + traj.size() - 1]),
+        extractJoints(*model, *solved_path[seed_path.size() - 1]));
+
+    // Break out the process path from the seed path and convert to ROS messages
+    DescartesTraj process_part(solved_path.begin() + to_process.size(),
+                               solved_path.end() - from_process.size());
+    trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *model);
+
+    for (std::size_t i = 0; i < process.points.size(); ++i)
+    {
+      const auto& pt = process.points[i];
+      if (!model->isValid(pt.positions))
+      {
+        ROS_WARN_STREAM("Position in blending path (" << i << ") invalid: Joint limit or collision detected\n");
+        return false;
+      }
+    }
+
+
+    // Fill in result trajectories
+    plan.trajectory_process = process;
+    plan.trajectory_approach = approach;
+    plan.trajectory_depart = depart;
+
+    // Fill in result header information
+    const std::vector<std::string>& joint_names =
+        moveit_model->getJointModelGroup(move_group_name)->getActiveJointModelNames();
+
+    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_approach);
+    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_depart);
+    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_process);
+    return true;
+  }
+  catch (const std::runtime_error& e)
+  {
+    ROS_ERROR_STREAM("Exception caught when planning blending path: " << e.what());
+    return false;
+  }
+}

--- a/godel_process_planning/src/generate_motion_plan.h
+++ b/godel_process_planning/src/generate_motion_plan.h
@@ -1,0 +1,34 @@
+#ifndef GODEL_GENERATE_MOTION_PLAN_H
+#define GODEL_GENERATE_MOTION_PLAN_H
+
+#include <descartes_core/robot_model.h>
+#include <descartes_core/trajectory_pt.h>
+#include <godel_msgs/ProcessPlan.h>
+
+namespace godel_process_planning
+{
+
+/**
+ * @brief This is a helper function for doing the joint level trajectory planning for a
+ * a robot from a given \e start_state to and through the process path defined by \e
+ * traj.
+ * @param model A descartes robot model for this process/tool
+ * @param traj A sequence of descartes points encapsulating the path tolerances
+ * @param moveit_model A moveit robot model corresponding to the robot used
+ * @param move_group_name The name of the move group being manipulated
+ * @param start_state The initial position of the robot
+ * @param plan Output parameter - the approach, process, and departure joint paths.
+ * NOTE THAT ProcessPlan::type is NOT set.
+ * @return True on planning success, false otherwise
+ */
+bool generateMotionPlan(const descartes_core::RobotModelPtr model,
+                        const std::vector<descartes_core::TrajectoryPtPtr>& traj,
+                        moveit::core::RobotModelConstPtr moveit_model,
+                        const std::string& move_group_name,
+                        const std::vector<double>& start_state,
+                        godel_msgs::ProcessPlan& plan);
+
+
+}
+
+#endif // GODEL_GENERATE_MOTION_PLAN_H

--- a/godel_process_planning/src/keyence_process_planning.cpp
+++ b/godel_process_planning/src/keyence_process_planning.cpp
@@ -87,7 +87,13 @@ bool ProcessPlanningManager::handleKeyencePlanning(godel_msgs::KeyenceProcessPla
   if (req.path.segments.empty())
   {
     ROS_WARN("%s: Cannot create scan process plan for empty trajectory", __FUNCTION__);
-    return false;
+    return true;
+  }
+
+  if (req.path.segments.size() > 1)
+  {
+    ROS_WARN("%s: Currently we do not support scan paths w/ more than 1 segment."
+             " Planning only for the first.", __FUNCTION__);
   }
 
   // Transform process path from geometry msgs to descartes points

--- a/godel_process_planning/src/keyence_process_planning.cpp
+++ b/godel_process_planning/src/keyence_process_planning.cpp
@@ -7,45 +7,13 @@
 #include "descartes_planner/dense_planner.h"
 
 #include "common_utils.h"
-
-// FILE LOCAL CONSTANTS
-const static std::string JOINT_TOPIC_NAME =
-    "joint_states"; // ROS topic to subscribe to for robot state
-const double FREE_SPACE_MAX_ANGLE_DELTA =
-    M_PI_2; // The maximum angle a joint during a freespace motion
-            // from the start to end position without that motion
-            // being penalized. Avoids flips.
-const double FREE_SPACE_ANGLE_PENALTY =
-    5.0; // The factor by which a joint motion is multiplied if said
-         // motion is greater than the max.
+#include "generate_motion_plan.h"
 
 namespace godel_process_planning
 {
 
-/**
- * @brief Computes a 'cost' value for a robot motion between 'source' and 'target'
- * @param source  The joint configuration at start of motion
- * @param target  The joint configuration at end of motion
- * @return cost value
- */
- double freeSpaceCostFunctionScan(const std::vector<double>& source,
-                                  const std::vector<double>& target)
-{
-  // The cost function here penalizes large single joint motions in an effort to
-  // keep the robot from flipping a joint, even if some other joints have to move
-  // a bit more.
-  double cost = 0.0;
-  for (std::size_t i = 0; i < source.size(); ++i)
-  {
-    double diff = std::abs(source[i] - target[i]);
-    if (diff > FREE_SPACE_MAX_ANGLE_DELTA)
-      cost += FREE_SPACE_ANGLE_PENALTY * diff;
-    else
-      cost += diff;
-  }
-  return cost;
-}
-
+const static std::string JOINT_TOPIC_NAME =
+    "joint_states"; // ROS topic to subscribe to for robot state
 /**
  * @brief Translated an Eigen pose to a Descartes trajectory point appropriate for the scan process!
  *        Mirros the function in blend_process_planning.cpp document.
@@ -72,38 +40,6 @@ static inline descartes_core::TrajectoryPtPtr toDescartesPt(const Eigen::Affine3
       ToleranceBase::createSymmetric<OrientationTolerance>(rx, ry, rz, 0, 0, M_PI));
 
   return TrajectoryPtPtr(new CartTrajectoryPt(frame, 0.0, M_PI, tm));
-}
-
-/**
- * @brief transforms an input, in the form of a reference pose and points relative to that pose,
- * into Descartes'
- *        native format. Also adds in associated parameters.
- * @param ref The reference posed that all points are multiplied by. Should be in the world space of
- * the keyence move group.
- * @param points Sequence of points (relative to ref and the world space of blending robot model)
- * @param params Surface blending parameters, including info such as traversal speed
- * @return The input trajectory encoded in Descartes points
- */
-static godel_process_planning::DescartesTraj
-toDescartesTraj(const geometry_msgs::Pose& ref, const std::vector<geometry_msgs::Point>& points,
-                const godel_msgs::ScanPlanParameters& params)
-{
-  DescartesTraj traj;
-  traj.reserve(points.size());
-  if (points.empty())
-    return traj;
-
-  Eigen::Affine3d last_pose = createNominalTransform(ref, points.front());
-
-  for (std::size_t i = 0; i < points.size(); ++i)
-  {
-    Eigen::Affine3d this_pose = createNominalTransform(ref, points[i]);
-    double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
-    traj.push_back(toDescartesPt(this_pose, dt));
-    last_pose = this_pose;
-  }
-
-  return traj;
 }
 
 /**
@@ -143,10 +79,10 @@ toDescartesTraj(const geometry_msgs::PoseArray& ref,
  * @param res Set of approach, process, and departure trajectories
  * @return True if a valid plan was generated; false otherwise
  */
-bool ProcessPlanningManager::handleKeyencePlanning(
-    godel_msgs::KeyenceProcessPlanning::Request& req,
-    godel_msgs::KeyenceProcessPlanning::Response& res)
+bool ProcessPlanningManager::handleKeyencePlanning(godel_msgs::KeyenceProcessPlanning::Request& req,
+                                                   godel_msgs::KeyenceProcessPlanning::Response& res)
 {
+  keyence_model_->setCheckCollisions(true);
   // Precondition: Input trajectory must be non-zero
   if (req.path.segments.empty())
   {
@@ -160,93 +96,16 @@ bool ProcessPlanningManager::handleKeyencePlanning(
   // Capture the current state of the robot
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
 
-  // Compute all of the joint poses at the start of the process path
-  std::vector<std::vector<double> > start_joint_poses;
-  process_points.front()->getJointPoses(*keyence_model_, start_joint_poses);
-
-  if (start_joint_poses.empty())
+  if (generateMotionPlan(keyence_model_, process_points, moveit_model_, keyence_group_name_,
+                         current_joints, res.plan))
   {
-    ROS_WARN_STREAM("Keyence Planning Service: Could not compute any inverse kinematic solutions for "
-                    "the first point in the process path.");
-
-    return false;
-  }
-
-  auto start_pose = pickBestStartPose(current_joints, *keyence_model_, start_joint_poses, freeSpaceCostFunctionScan);
-
-  DescartesTraj solved_path;
-  // Calculate tool pose of robot starting config so that we can go back here on the
-  // return move
-  Eigen::Affine3d init_pose;
-  keyence_model_->getFK(current_joints, init_pose);
-  // Compute the nominal tool pose of the final process point
-  Eigen::Affine3d process_stop_pose;
-  process_points.back()->getNominalCartPose(std::vector<double>(), *keyence_model_,
-                                            process_stop_pose);
-
-  // Joint interpolate from the initial robot position to 'best' starting configuration of process
-  // path
-  DescartesTraj to_process = createJointPath(current_joints, start_pose);
-  to_process.front() =
-      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
-
-  // To get a rough estimate of process path cost, add a cartesian move from the final process point
-  // to the starting position again.
-  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
-  from_process.back() =
-      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(current_joints));
-
-  // Stitch the above approach and departure trajectories in with the original path
-  DescartesTraj seed_path;
-  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
-  seed_path.insert(seed_path.end(), process_points.begin(), process_points.end());
-  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
-
-  // Attempt to solve the initial path
-  if (!descartesSolve(seed_path, keyence_model_, solved_path))
-  {
-    ROS_ERROR_STREAM("Descartes unable to solve scanning path");
-    return false;
-  }
-
-  // Refine the approach and depart plans by attempting joint interpolation and using MoveIt if
-  // necessary
-  try
-  {
-    trajectory_msgs::JointTrajectory approach =
-        planFreeMove(*keyence_model_, keyence_group_name_, moveit_model_,
-                     extractJoints(*keyence_model_, *solved_path[0]),
-                     extractJoints(*keyence_model_, *solved_path[to_process.size()]));
-
-    trajectory_msgs::JointTrajectory depart = planFreeMove(
-        *keyence_model_, keyence_group_name_, moveit_model_,
-        extractJoints(*keyence_model_, *solved_path[to_process.size() + process_points.size() - 1]),
-        extractJoints(*keyence_model_, *solved_path[seed_path.size() - 1]));
-    // Segment out process path from initial solution
-    DescartesTraj process_part(solved_path.begin() + to_process.size(),
-                               solved_path.end() - from_process.size());
-    trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *keyence_model_);
-
-    // Translate the Descartes trajectory into a ROS joint trajectory
-    const std::vector<std::string>& joint_names =
-        moveit_model_->getJointModelGroup(keyence_group_name_)->getActiveJointModelNames();
-
-    res.plan.trajectory_process = process;
-    res.plan.trajectory_approach = approach;
-    res.plan.trajectory_depart = depart;
-
-    godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_approach);
-    godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_depart);
-    godel_process_planning::fillTrajectoryHeaders(joint_names, res.plan.trajectory_process);
-
-    res.plan.type = godel_msgs::ProcessPlan::SCAN_TYPE;
-
+    res.plan.type = res.plan.SCAN_TYPE;
     return true;
   }
-  catch (std::runtime_error& e)
+  else
   {
-    ROS_ERROR_STREAM("Exception caught when planning keyence scan path: " << e.what());
     return false;
   }
 }
+
 }

--- a/godel_process_planning/src/keyence_process_planning.cpp
+++ b/godel_process_planning/src/keyence_process_planning.cpp
@@ -148,14 +148,14 @@ bool ProcessPlanningManager::handleKeyencePlanning(
     godel_msgs::KeyenceProcessPlanning::Response& res)
 {
   // Precondition: Input trajectory must be non-zero
-  if (req.path.poses.poses.empty())
+  if (req.path.segments.empty())
   {
     ROS_WARN("%s: Cannot create scan process plan for empty trajectory", __FUNCTION__);
     return false;
   }
 
   // Transform process path from geometry msgs to descartes points
-  DescartesTraj process_points = toDescartesTraj(req.path.poses, req.params);
+  DescartesTraj process_points = toDescartesTraj(req.path.segments[0], req.params);
 
   // Capture the current state of the robot
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);

--- a/godel_surface_detection/include/coordination/data_coordinator.h
+++ b/godel_surface_detection/include/coordination/data_coordinator.h
@@ -34,8 +34,8 @@ namespace data
       pcl::PolygonMesh surface_mesh_;
       pcl::PointCloud<pcl::PointXYZRGB> surface_cloud_;
       std::vector<std::pair<std::string, geometry_msgs::PoseArray>> edge_pairs_;
-      geometry_msgs::PoseArray blend_poses_;
-      geometry_msgs::PoseArray scan_poses_;
+      std::vector<geometry_msgs::PoseArray> blend_poses_;
+      std::vector<geometry_msgs::PoseArray> scan_poses_;
   };
 
 
@@ -75,8 +75,8 @@ namespace data
     bool addEdge(int id, std::string name, geometry_msgs::PoseArray edge_poses);
     bool renameEdge(int id, std::string old_name, std::string new_name);
     bool getEdgePosesByName(const std::string& edge_name, geometry_msgs::PoseArray& edge_poses);
-    bool setPoses(PoseTypes pose_type, int id, geometry_msgs::PoseArray poses);
-    bool getPoses(PoseTypes pose_type, int id, geometry_msgs::PoseArray& poses);
+    bool setPoses(PoseTypes pose_type, int id, const std::vector<geometry_msgs::PoseArray>& poses);
+    bool getPoses(PoseTypes pose_type, int id, std::vector<geometry_msgs::PoseArray>& poses);
   };
 } /* end namespace data */
 } /* end namespace godel_surface_detection */

--- a/godel_surface_detection/include/services/surface_blending_service.h
+++ b/godel_surface_detection/include/services/surface_blending_service.h
@@ -55,9 +55,9 @@ const static std::string TOOL_NAMESPACE = "process_tool";
 
 struct ProcessPathDetails
 {
-  std::vector<geometry_msgs::PoseArray> blend_poses_;
+  std::vector<std::vector<geometry_msgs::PoseArray>> blend_poses_;
   std::vector<geometry_msgs::PoseArray> edge_poses_;
-  std::vector<geometry_msgs::PoseArray> scan_poses_;
+  std::vector<std::vector<geometry_msgs::PoseArray>> scan_poses_;
 };
 
 /**
@@ -66,7 +66,7 @@ struct ProcessPathDetails
  */
 struct ProcessPathResult
 {
-  typedef std::pair<std::string, geometry_msgs::PoseArray> value_type;
+  typedef std::pair<std::string, std::vector<geometry_msgs::PoseArray>> value_type;
   std::vector<value_type> paths;
 };
 /**
@@ -161,7 +161,7 @@ private:
 
 
   ProcessPlanResult generateProcessPlan(const std::string& name,
-                                        const geometry_msgs::PoseArray& path,
+                                        const std::vector<geometry_msgs::PoseArray> &path,
                                         const godel_msgs::BlendingPlanParameters& params,
                                         const godel_msgs::ScanPlanParameters& scan_params);
 

--- a/godel_surface_detection/src/coordination/data_coordinator.cpp
+++ b/godel_surface_detection/src/coordination/data_coordinator.cpp
@@ -292,7 +292,7 @@ namespace data
    * @param poses PoseArray containing pose data
    * @return true if record is found, false otherwise
    */
-  bool DataCoordinator::setPoses(PoseTypes pose_type, int id, geometry_msgs::PoseArray poses)
+  bool DataCoordinator::setPoses(PoseTypes pose_type, int id, const std::vector<geometry_msgs::PoseArray>& poses)
   {
     for(auto& rec : records_)
     {
@@ -332,7 +332,7 @@ namespace data
    * @param poses
    * @return
    */
-  bool DataCoordinator::getPoses(PoseTypes pose_type, int id, geometry_msgs::PoseArray& poses)
+  bool DataCoordinator::getPoses(PoseTypes pose_type, int id, std::vector<geometry_msgs::PoseArray>& poses)
   {
     for(auto& rec : records_)
     {

--- a/godel_surface_detection/src/services/blending_service_path_generation.cpp
+++ b/godel_surface_detection/src/services/blending_service_path_generation.cpp
@@ -359,7 +359,7 @@ SurfaceBlendingService::generateProcessPlan(const std::string& name,
   if (isBlendingPath(name))
   {
     godel_msgs::BlendProcessPlanning srv;
-    srv.request.path.poses = poses;
+    srv.request.path.segments.push_back(poses);
     srv.request.params = params;
 
     success = blend_planning_client_.call(srv);
@@ -368,7 +368,7 @@ SurfaceBlendingService::generateProcessPlan(const std::string& name,
   else if (isEdgePath(name))
   {
     godel_msgs::BlendProcessPlanning srv;
-    srv.request.path.poses = poses;
+    srv.request.path.segments.push_back(poses);
     srv.request.params = params;
 
     success = blend_planning_client_.call(srv);
@@ -377,7 +377,7 @@ SurfaceBlendingService::generateProcessPlan(const std::string& name,
   else
   {
     godel_msgs::KeyenceProcessPlanning srv;
-    srv.request.path.poses = poses;
+    srv.request.path.segments.push_back(poses);
     srv.request.params = scan_params;
 
     success = keyence_planning_client_.call(srv);


### PR DESCRIPTION
This PR changes the process planner to accept paths that are composed of not just one PoseArray, but a sequence of PoseArray objects. Transitions are made between segments by picking the tool up to the "safe traversal height" and moving again.

It does not change the core planning service beyond a couple lines of interface code.