### PR TITLE
Industrial CI Fixes

### DIFF
--- a/.install-libsocket++.sh
+++ b/.install-libsocket++.sh
@@ -1,6 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -ex
+pushd .
+cd /tmp
 git clone https://github.com/dermesser/libsocket
 cd libsocket
 mkdir build && cd build
 cmake .. && make && sudo make install
+popd


### PR DESCRIPTION
Folks over at industrial ci made the main source directory for their builds read only.

This downloads source into the temp directory instead.