### PR TITLE
Reflect libsocket-keyence update & package.ml changes

### DIFF
--- a/.install-libsocket++.sh
+++ b/.install-libsocket++.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -ex
-pushd .
-cd /tmp
-git clone https://github.com/dermesser/libsocket
-cd libsocket
-mkdir build && cd build
-cmake .. && make && sudo make install
-popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required 
-dist: trusty 
+dist: xenial 
 language: generic 
 compiler:
   - gcc
@@ -13,7 +13,6 @@ env:
     - UPSTREAM_WORKSPACE=file
     - ROSINSTALL_FILENAME=godel.rosinstall
     - NOT_TEST_INSTALL=true
-    - BEFORE_SCRIPT='./.install-libsocket++.sh'
   matrix:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
@@ -21,4 +20,3 @@ install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 
   - source .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C
   wstool update
   rosdep install --from-paths . --ignore-src
   ```
-- Godel currently depends on [keyence_experimental](https://github.com/ros-industrial/keyence_experimental). Build the library by following the instructions [here](https://github.com/ros-industrial/keyence_experimental#build)
 
 - Finally, to build:
   ```

--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,14 +1,11 @@
-- git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git',
-    version: kinetic-devel}
-- git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git',
-    version: hydro-devel}
-- git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git',
-    version: kinetic-devel}
-- git: {local-name: industrial_core, uri: 'https://github.com/ros-industrial/industrial_core.git',
-    version: kinetic-devel}
-- git: {local-name: keyence_experimental, uri: 'https://github.com/ros-industrial/keyence_experimental.git',
-    version: kinetic-devel}
+- git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git', version: kinetic-devel}
+- git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git', version: hydro-devel}
+- git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git', version: kinetic-devel}
+- git: {local-name: industrial_core, uri: 'https://github.com/ros-industrial/industrial_core.git', version: kinetic-devel}
+- git: {local-name: keyence_experimental, uri: 'https://github.com/ros-industrial/keyence_experimental.git', version: kinetic-devel}
 
 # Custom abb until Kinetic release happens
-- git: {local-name: abb, uri: 'https://github.com/Jmeyer1292/abb.git',
-    version: kinetic-devel}
+- git: {local-name: abb, uri: 'https://github.com/Jmeyer1292/abb.git', version: kinetic-devel}
+
+# Use until PR #45 is merged with https://github.com/dermesser/libsocket.git
+- git: {local-name: libsocket, uri: 'https://github.com/AustinDeric/libsocket.git', version: kinetic-devel}

--- a/godel/package.xml
+++ b/godel/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel</name>
   <version>0.0.0</version>
   <description>The godel metapackage</description>
@@ -9,12 +9,12 @@
   <license>Apache2</license>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>godel_plugins</run_depend>
-  <run_depend>godel_path_planning</run_depend>
-  <run_depend>godel_process_path_generation</run_depend>
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>godel_surface_detection</run_depend>
-  <run_depend>godel_polygon_offset</run_depend>
+  <exec_depend>godel_plugins</exec_depend>
+  <exec_depend>godel_path_planning</exec_depend>
+  <exec_depend>godel_process_path_generation</exec_depend>
+  <exec_depend>godel_msgs</exec_depend>
+  <exec_depend>godel_surface_detection</exec_depend>
+  <exec_depend>godel_polygon_offset</exec_depend>
 
   <export>
     <metapackage/>

--- a/godel_msgs/package.xml
+++ b/godel_msgs/package.xml
@@ -1,25 +1,19 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_msgs</name>
   <version>0.0.0</version>
   <description>The godel_msgs package</description>
+
   <maintainer email="jnicho@swri.org">jnicho</maintainer>
   <license>Apache2</license>
 
-
   <buildtool_depend>catkin</buildtool_depend>
-
-  <build_depend>genmsg</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
   
-  <run_depend>genmsg</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
+  <depend>genmsg</depend>
+  <depend>geometry_msgs</depend>
+  <depend>message_runtime</depend>
+  <depend>sensor_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>visualization_msgs</depend>
+
 </package>

--- a/godel_param_helpers/package.xml
+++ b/godel_param_helpers/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_param_helpers</name>
   <version>0.1.0</version>
   <description>
@@ -8,12 +8,10 @@
   </description>
 
   <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <run_depend>roscpp</run_depend>
+  <depend>roscpp</depend>
 
 </package>

--- a/godel_path_execution/package.xml
+++ b/godel_path_execution/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_path_execution</name>
   <version>0.1.0</version>
   <description>
@@ -10,19 +10,13 @@
   </description>
 
   <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>actionlib</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>industrial_robot_simulator_service</build_depend>
-
-  <run_depend>actionlib</run_depend
-  ><run_depend>godel_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>industrial_robot_simulator_service</run_depend>
+  <depend>actionlib</depend>
+  <depend>godel_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>industrial_robot_simulator_service</depend>
 
 </package>

--- a/godel_plugins/package.xml
+++ b/godel_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_plugins</name>
   <version>0.1.0</version>
   <description>
@@ -11,21 +11,16 @@
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <build_depend>roscpp</build_depend>
-  <build_depend>rqt_gui</build_depend>
-  <build_depend>rqt_gui_cpp</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>rviz</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>rqt_gui</run_depend>
-  <run_depend>rqt_gui_cpp</run_depend>
-  <run_depend>rviz</run_depend>
-  <run_depend>godel_msgs</run_depend>
+  <depend>roscpp</depend>
+  <depend>rqt_gui</depend>
+  <depend>rqt_gui_cpp</depend>
+  <depend>rviz</depend>
+  <depend>godel_msgs</depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
     <rviz plugin="${prefix}/plugin.xml"/>
   </export>
+
 </package>

--- a/godel_polygon_offset/package.xml
+++ b/godel_polygon_offset/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_polygon_offset</name>
   <version>0.0.0</version>
   <description>The godel_polygon_offset package implements a method to create offset polygons from  an input set of polygon boundaries. This package utilizes the openvoronoi package created by Anders Wallin https://github.com/aewallin/openvoronoi/ </description>
@@ -9,26 +9,17 @@
   <url type="website">https://github.com/ros-industrial/godel/godel_polygon_offset</url>
   <author email="dpsolomon@gmail.com">Dan Solomon</author>
 
-  <!-- Build/run/test depends -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
+  <depend>geometry_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>godel_process_path_generation</depend>
+  <depend>godel_openvoronoi</depend>
+  <depend>path_planning_plugins</depend>
+
   <build_depend>message_generation</build_depend>
   <build_depend>cmake_modules</build_depend>
-  <build_depend>godel_process_path_generation</build_depend>
-  <build_depend>godel_openvoronoi</build_depend>
-  <build_depend>path_planning_plugins</build_depend>
 
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>godel_process_path_generation</run_depend>
-  <run_depend>godel_openvoronoi</run_depend>
-  <run_depend>path_planning_plugins</run_depend>
+  <exec_depend>message_runtime</exec_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-  </export>
 </package>

--- a/godel_process_execution/package.xml
+++ b/godel_process_execution/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_process_execution</name>
   <version>0.1.0</version>
   <description>
@@ -9,20 +9,14 @@
   </description>
 
   <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>abb_file_suite</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>industrial_robot_simulator_service</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>keyence_experimental</build_depend>
+  <depend>abb_file_suite</depend>
+  <depend>godel_msgs</depend>
+  <depend>industrial_robot_simulator_service</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>keyence_experimental</depend>
 
-  <run_depend>abb_file_suite</run_depend>
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>industrial_robot_simulator_service</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>keyence_experimental</run_depend>
 </package>

--- a/godel_process_path_generation/package.xml
+++ b/godel_process_path_generation/package.xml
@@ -1,45 +1,29 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_process_path_generation</name>
   <version>0.0.0</version>
   <description>
   The godel_process_path_generation package creates the high-level process path for surface blending.
   </description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <maintainer email="dpsolomon@gmail.com">Daniel Solomon</maintainer>
+  <author email="dpsolomon@gmail.com">Daniel Solomon</author>
   <license>Apache2</license>
   <url type="website">https://github.com/ros-industrial-consortium/godel</url>
-  <author email="dpsolomon@gmail.com">Daniel Solomon</author>
 
-  <!-- Build/run/test depends -->
   <buildtool_depend>catkin</buildtool_depend>
   
-  <build_depend>roscpp</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>eigen_conversions</build_depend>
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>moveit_ros_planning_interface</build_depend>
-  
-  <run_depend>roscpp</run_depend>
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>eigen_conversions</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>moveit_ros_planning_interface</run_depend>
-    
-  <!-- <test_depend></test_depend> -->
+  <depend>roscpp</depend>
+  <depend>godel_msgs</depend>
+  <depend>tf</depend>
+  <depend>geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>eigen_conversions</depend>
+  <depend>moveit_core</depend>
+  <depend>moveit_ros_planning_interface</depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-  </export>
+  <build_depend>trajectory_msgs</build_depend>
+  <build_depend>cmake_modules</build_depend>
+
 </package>

--- a/godel_process_planning/package.xml
+++ b/godel_process_planning/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_process_planning</name>
   <version>0.1.0</version>
   <description>
@@ -9,25 +9,16 @@
 
   <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
   <author email="jmeyer@swri.org">Jonathan Meyer</author>
-  
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>descartes_core</build_depend>
-  <build_depend>descartes_moveit</build_depend>
-  <build_depend>descartes_planner</build_depend>
-  <build_depend>descartes_trajectory</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>moveit_ros_planning_interface</build_depend>
-  <build_depend>roscpp</build_depend>
-
-  <run_depend>descartes_core</run_depend>
-  <run_depend>descartes_moveit</run_depend>
-  <run_depend>descartes_planner</run_depend>
-  <run_depend>descartes_trajectory</run_depend>
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>moveit_ros_planning_interface</run_depend>
-  <run_depend>roscpp</run_depend>
+  <depend>descartes_core</depend>
+  <depend>descartes_moveit</depend>
+  <depend>descartes_planner</depend>
+  <depend>descartes_trajectory</depend>
+  <depend>godel_msgs</depend>
+  <depend>moveit_ros_planning_interface</depend>
+  <depend>roscpp</depend>
 
 </package>

--- a/godel_robots/abb/abb_file_suite/package.xml
+++ b/godel_robots/abb/abb_file_suite/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>abb_file_suite</name>
   <version>0.1.0</version>
   <description>
@@ -11,16 +11,12 @@
 
   <author email="jmeyer@swri.org">Jonathan Meyer</author>
   <author email="Zachary.Bennett@wolfrobotics.com">Zach Bennett</author>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
+  <depend>roscpp</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>message_runtime</depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
 </package>

--- a/godel_robots/abb/godel_irb2400/abb_irb2400_descartes/package.xml
+++ b/godel_robots/abb/godel_irb2400/abb_irb2400_descartes/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>abb_irb2400_descartes</name>
   <version>0.1.0</version>
   <description>
@@ -8,22 +8,17 @@
   </description>
 
   <maintainer email="Jmeyer@swri.org">Jonathan Meyer</maintainer>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>descartes_core</build_depend>
-  <build_depend>descartes_moveit</build_depend>
-  <build_depend>irb2400_ikfast_manipulator_plugin</build_depend>
-  <build_depend>pluginlib</build_depend>
-
-  <run_depend>descartes_core</run_depend>
-  <run_depend>descartes_moveit</run_depend>
-  <run_depend>irb2400_ikfast_manipulator_plugin</run_depend>
-  <run_depend>pluginlib</run_depend>
+  <depend>descartes_core</depend>
+  <depend>descartes_moveit</depend>
+  <depend>irb2400_ikfast_manipulator_plugin</depend>
+  <depend>pluginlib</depend>
 
   <export>
     <descartes_core plugin="${prefix}/abb_irb2400_descartes_plugins.xml"/>
   </export>
+
 </package>

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_moveit_config/package.xml
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_moveit_config/package.xml
@@ -1,27 +1,25 @@
-<package>
-
+<package format="2">
   <name>godel_irb2400_moveit_config</name>
   <version>0.2.0</version>
   <description>
      An automatically generated package with all the configuration and launch files for using the irb2400_workspace with the MoveIt Motion Planning Framework
   </description>
+
   <author email="assistant@moveit.ros.org">MoveIt Setup Assistant</author>
   <maintainer email="assistant@moveit.ros.org">MoveIt Setup Assistant</maintainer>
-
   <license>BSD</license>
-
   <url type="website">http://moveit.ros.org/</url>
   <url type="bugtracker">https://github.com/ros-planning/moveit_setup_assistant/issues</url>
   <url type="repository">https://github.com/ros-planning/moveit_setup_assistant</url>
 
-  <run_depend>moveit_ros_move_group</run_depend>
-  <run_depend>moveit_planners_ompl</run_depend>
-  <run_depend>moveit_ros_visualization</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>robot_state_publisher</run_depend>
-  <run_depend>xacro</run_depend>
-
-
   <buildtool_depend>catkin</buildtool_depend>
+
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_planners_ompl</exec_depend>
+  <exec_depend>moveit_ros_visualization</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
+
   
 </package>

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/package.xml
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_irb2400_support</name>
   <version>0.1.0</version>
   <description>
@@ -12,7 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>godel_robot_resources</run_depend>
-  <run_depend>godel_surface_detection</run_depend>
+  <exec_depend>godel_robot_resources</exec_depend>
+  <exec_depend>godel_surface_detection</exec_depend>
 
 </package>

--- a/godel_robots/abb/godel_irb2400/irb2400_ikfast_manipulator_plugin/package.xml
+++ b/godel_robots/abb/godel_irb2400/irb2400_ikfast_manipulator_plugin/package.xml
@@ -1,33 +1,24 @@
 <?xml version='1.0' encoding='ASCII'?>
-<package>
+<package format="2">
   <name>irb2400_ikfast_manipulator_plugin</name>
-  
   <version>0.1.0</version>
-  
   <description>
     IKFast plugin for the ABB2400; used for closed form IK in Godel
   </description>
   
   <maintainer email="jmeyer@swri.og">Jonathan Meyer</maintainer>
-  
   <license>Apache 2.0</license>
   
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <build_depend>liblapack-dev</build_depend>
-  <build_depend>moveit_core</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  
-  <run_depend>liblapack-dev</run_depend>
-  <run_depend>moveit_core</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf_conversions</run_depend>
+
+  <depend>liblapack-dev</depend>
+  <depend>moveit_core</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf_conversions</depend>
   
   <export>
     <moveit_core plugin="${prefix}/abb_irb2400_manipulator_moveit_ikfast_plugin_description.xml"/>
   </export>
-  <build_depend>moveit_core</build_depend>
+
 </package>

--- a/godel_robots/godel_robot_resources/package.xml
+++ b/godel_robots/godel_robot_resources/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_robot_resources</name>
   <version>0.1.0</version>
   <description>

--- a/godel_scan_analysis/package.xml
+++ b/godel_scan_analysis/package.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_scan_analysis</name>
   <version>0.0.0</version>
   <description>Generates colorized point clouds from individual profilimeter
   laser scans. </description>
 
   <maintainer email="jonathan.meyer@swri.org">Jon Meyer</maintainer>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>roscpp</run_depend>
+
+  <depend>pcl_ros</depend>
+  <depend>roscpp</depend>
 
 </package>

--- a/godel_simple_gui/package.xml
+++ b/godel_simple_gui/package.xml
@@ -1,24 +1,21 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_simple_gui</name>
   <version>0.1.0</version>
   <description>The godel_simple_gui package presents an alternative front end for the Godel project that is focused on providing an easy to use, ATM-like interface for operating the system end to end.</description>
 
   <maintainer email="jmeyer@swri.org">Jonathan Meyer</maintainer>
   <author email="jmeyer@swri.org">Jonathan Meyer</author>
-
   <license>Apache 2.0</license>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rviz</build_depend>
 
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>rviz</run_depend>
+  <depend>godel_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>rviz</depend>
 
   <export>
    <rviz plugin="${prefix}/plugin.xml"/>
   </export>
+
 </package>

--- a/godel_surface_detection/package.xml
+++ b/godel_surface_detection/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>godel_surface_detection</name>
   <version>0.1.0</version>
   
@@ -16,34 +16,21 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   
-  <build_depend>pcl_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>interactive_markers</build_depend>
-  <build_depend>moveit_ros_move_group</build_depend>
-  <build_depend>moveit_ros_planning_interface</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>tf_conversions</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>godel_param_helpers</build_depend>
-  <build_depend>godel_process_path_generation</build_depend>
-  <build_depend>godel_plugins</build_depend>
-  <build_depend>meshing_plugins_base</build_depend>
-  <build_depend>path_planning_plugins_base</build_depend>
+  <depend>pcl_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>interactive_markers</depend>
+  <depend>moveit_ros_planning_interface</depend>
+  <depend>tf</depend>
+  <depend>tf_conversions</depend>
+  <depend>godel_msgs</depend>
+  <depend>godel_process_path_generation</depend>
+  <depend>godel_param_helpers</depend>
+  <depend>godel_plugins</depend>
+  <depend>meshing_plugins_base</depend>
+  <depend>path_planning_plugins_base</depend>
 
-  <run_depend>pcl_msgs</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>interactive_markers</run_depend>
-  <run_depend>moveit_ros_planning_interface</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>tf_conversions</run_depend>
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>godel_process_path_generation</run_depend>
-  <run_depend>godel_param_helpers</run_depend>
-  <run_depend>godel_plugins</run_depend>
-  <run_depend>meshing_plugins_base</run_depend>
-  <run_depend>path_planning_plugins_base</run_depend>
+  <build_depend>moveit_ros_move_group</build_depend>
+
 </package>

--- a/industrial_robot_simulator_service/package.xml
+++ b/industrial_robot_simulator_service/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>industrial_robot_simulator_service</name>
   <version>0.1.0</version>
   <description>
@@ -10,22 +10,18 @@
 
   <maintainer email="jonathan.meyer@swri.org">Jonathan Meyer</maintainer>
   <author email="jonathan.meyer@swri.org">Jonathan Meyer</author>
-
   <license>Apache 2.0</license>
-
-  <build_depend>message_generation</build_depend>
-  <run_depend>message_runtime</run_depend>
   
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>actionlib</build_depend>
-  <build_depend>control_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
+  <depend>actionlib</depend>
+  <depend>control_msgs</depend>
+  <depend>industrial_robot_simulator</depend>
+  <depend>roscpp</depend>
+  <depend>trajectory_msgs</depend>
 
-  <run_depend>actionlib</run_depend>
-  <run_depend>control_msgs</run_depend>
-  <run_depend>industrial_robot_simulator</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
+  <build_depend>message_generation</build_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+
 </package>

--- a/meshing_plugins/package.xml
+++ b/meshing_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>meshing_plugins</name>
   <version>0.1.0</version>
   <description>
@@ -11,21 +11,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>meshing_plugins_base</build_depend>
-  <build_depend>path_planning_plugins_base</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>meshing_plugins_base</run_depend>
-  <run_depend>path_planning_plugins_base</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
+  <depend>godel_msgs</depend>
+  <depend>meshing_plugins_base</depend>
+  <depend>path_planning_plugins_base</depend>
+  <depend>pcl_ros</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
 
   <export>
     <meshing_plugins_base plugin="${prefix}/plugin.xml"/>
   </export>
+
 </package>

--- a/meshing_plugins_base/package.xml
+++ b/meshing_plugins_base/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>meshing_plugins_base</name>
   <version>0.1.0</version>
   <description>
@@ -11,9 +11,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
+  <depend>pcl_ros</depend>
+  <depend>roscpp</depend>
 
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>roscpp</run_depend>
 </package>

--- a/path_planning_plugins/package.xml
+++ b/path_planning_plugins/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>path_planning_plugins</name>
   <version>0.0.1</version>
   <description>
@@ -11,29 +11,19 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cmake_modules</build_depend>
-  <build_depend>eigen_conversions</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>godel_msgs</build_depend>
-  <build_depend>godel_process_path_generation</build_depend>
-  <build_depend>path_planning_plugins_base</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf</build_depend>
-
-  <run_depend>cmake_modules</run_depend>
-  <run_depend>eigen_conversions</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>godel_msgs</run_depend>
-  <run_depend>godel_process_path_generation</run_depend>
-  <run_depend>path_planning_plugins_base</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf</run_depend>
+  <depend>cmake_modules</depend>
+  <depend>eigen_conversions</depend>
+  <depend>geometry_msgs</depend>
+  <depend>godel_msgs</depend>
+  <depend>godel_process_path_generation</depend>
+  <depend>path_planning_plugins_base</depend>
+  <depend>pcl_ros</depend>
+  <depend>pluginlib</depend>
+  <depend>roscpp</depend>
+  <depend>tf</depend>
 
   <export>
     <path_planning_plugins_base plugin="${prefix}/plugin.xml"/>
   </export>
+
 </package>

--- a/path_planning_plugins_base/package.xml
+++ b/path_planning_plugins_base/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>path_planning_plugins_base</name>
   <version>0.0.1</version>
   <description>
@@ -11,11 +11,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
+  <depend>geometry_msgs</depend>
+  <depend>pcl_ros</depend>
+  <depend>roscpp</depend>
 
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>pcl_ros</run_depend>
-  <run_depend>roscpp</run_depend>
 </package>


### PR DESCRIPTION
- Make all package.xml files the format 2 convention.
- update travis.yml to use new libsocketConfig.cmake change.
- update README.md to remove reference from seperate libsocket build process.
- remove libsocket install script because its built within rosinstall framework.

@Jmeyer1292 or @woodaaron please review.