### PR TITLE
Automated Laser Cloud Clearing

### DIFF
--- a/godel_process_execution/include/godel_process_execution/keyence_process_service.h
+++ b/godel_process_execution/include/godel_process_execution/keyence_process_service.h
@@ -28,6 +28,7 @@ private:
   ros::ServiceClient real_client_;
   ros::ServiceClient sim_client_;
   ros::ServiceClient keyence_client_;
+  ros::ServiceClient reset_scan_server_;
 };
 }
 

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
@@ -4,6 +4,8 @@
   <arg name="sim_robot" default="true"/>
   <arg name="robot_ip" unless="$(arg sim_robot)" />
   <arg name="sim_sensor" default="true"/>
+  <arg name="sim_laser" default="true"/>
+  <arg name="laser_ip" unless="$(arg sim_laser)" default="192.168.32.50"/>
   <arg name="robot_model_plugin" default="abb_irb2400_descartes/AbbIrb2400RobotModel"/>
   <arg name="debug_mode" default="false"/>
 
@@ -56,6 +58,21 @@
     <node name="ensenso_publisher_node" pkg="ensenso_publisher" type="ensenso_publisher_node" output="screen" required="true">
         <param name="FlexView" type="bool" value="true" />
         <param name="FlexViewImages" type="int" value="4" />
+    </node>
+  </group>
+
+  <group unless="$(arg sim_laser)">
+    <!--Bring up scan analysis code-->
+    <include file="$(find godel_scan_analysis)/launch/scan_analysis.launch">
+      <arg name="world_frame" value="world_frame"/>
+      <arg name="scan_frame" value="keyence_sensor_optical_frame"/>
+      <arg name="voxel_leaf_size" value="0.0005"/>
+    </include>
+
+    <!--Bring up the driver hardware for the Keyence-->
+    <node name="keyence_driver" pkg="keyence_experimental" type="keyence_driver_node">
+      <param name="controller_ip" value="$(arg laser_ip)"/>
+      <param name="frame_id" value="keyence_sensor_optical_frame"/>
     </node>
   </group>
   

--- a/godel_scan_analysis/CMakeLists.txt
+++ b/godel_scan_analysis/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(godel_scan_analysis)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS
   pcl_ros
   roscpp

--- a/godel_scan_analysis/include/godel_scan_analysis/keyence_scan_server.h
+++ b/godel_scan_analysis/include/godel_scan_analysis/keyence_scan_server.h
@@ -53,6 +53,11 @@ public:
    */
   ColorCloud::ConstPtr getSurfaceQuality() const { return map_; }
 
+  /**
+   * @brief Resets accumulated clouds (map_)
+   */
+  void clear();
+
 private:
   void transformScan(ColorCloud& cloud, const ros::Time& tm) const;
   tf::StampedTransform findTransform(const ros::Time& tm) const;

--- a/godel_scan_analysis/src/godel_scan_analysis_node.cpp
+++ b/godel_scan_analysis/src/godel_scan_analysis_node.cpp
@@ -1,16 +1,19 @@
 #include <ros/ros.h>
 
 #include "godel_scan_analysis/keyence_scan_server.h"
+#include <std_srvs/Trigger.h>
 
 const static std::string DEFAULT_WORLD_FRAME = "world_frame";
 const static std::string DEFAULT_SCAN_FRAME = "keyence_sensor_optical_frame";
 const static double VOXEL_GRID_LEAF_SIZE = 0.005;    // 5 mm
 const static double VOXEL_GRID_PUBLISH_PERIOD = 2.0; // seconds
 
+const static std::string DEFAULT_RESET_SERVICE = "reset_scan_server";
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "scan_server");
-  ros::NodeHandle pnh("~");
+  ros::NodeHandle pnh("~"), nh;
 
   // Populate a ScanServerConfiguration
   godel_scan_analysis::ScanServerConfig config;
@@ -34,6 +37,15 @@ int main(int argc, char** argv)
                     VOXEL_GRID_PUBLISH_PERIOD);
 
   godel_scan_analysis::ScanServer server(config);
+
+  // Advertise a service that enables outside nodes to reset the accumulated cloud
+  ros::ServiceServer reset_service =
+      nh.advertiseService<std_srvs::TriggerRequest, std_srvs::TriggerResponse>(DEFAULT_RESET_SERVICE,
+        [&server] (const std_srvs::TriggerRequest&, std_srvs::TriggerResponse&) {
+           server.clear();
+            return true;
+        }
+  );
 
   ROS_INFO("Godel scan server is online");
 

--- a/godel_scan_analysis/src/keyence_scan_server.cpp
+++ b/godel_scan_analysis/src/keyence_scan_server.cpp
@@ -60,6 +60,11 @@ void godel_scan_analysis::ScanServer::publishCloud(const ros::TimerEvent&) const
   cloud_pub_.publish(pub_cloud);
 }
 
+void godel_scan_analysis::ScanServer::clear()
+{
+  map_->clear();
+}
+
 void godel_scan_analysis::ScanServer::transformScan(ColorCloud& cloud, const ros::Time& tm) const
 {
   tf::StampedTransform transform = findTransform(tm);


### PR DESCRIPTION
Adds a very simple `trigger` service to the existing scan analysis code that clears the accumulated laser scan data. This trigger is actuated by the scan execution process.

I envision more changes to this interface as we go forward, but I wanted to keep it simple for Automate integration.