### PR TITLE
Crash on No Segmented Surfaces

### DIFF
--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -105,7 +105,10 @@ std::vector <pcl::PointIndices> SurfaceSegmentation::computeSegments(pcl::PointC
   rg.setInputNormals (normals_);
 
   rg.extract (clusters_);
-  colored_cloud = rg.getColoredCloud();
+
+  if (!clusters_.empty()) // Turns out getColoredCloud() returns a null ptr if it didn't segment any surfaces
+    colored_cloud = rg.getColoredCloud();
+
   return(clusters_);
 }
 


### PR DESCRIPTION
A PCL function returned a null pointer and that caused issues down the line. This introduces a check.

Addresses #171, at least partially (in simulation).