### PR TITLE
Segment Transitions at Specified Height

### DIFF
--- a/godel_process_planning/CMakeLists.txt
+++ b/godel_process_planning/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(godel_process_planning_node
   src/keyence_process_planning.cpp
   src/trajectory_utils.cpp
   src/generate_motion_plan.cpp
+  src/path_transitions.cpp
 )
 
 ## Add cmake target dependencies of the executable/library

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -8,8 +8,8 @@
 #include "descartes_planner/dense_planner.h"
 
 #include "common_utils.h"
+#include "path_transitions.h"
 #include "generate_motion_plan.h"
-#include "eigen_conversions/eigen_msg.h"
 #include "boost/make_shared.hpp"
 
 namespace godel_process_planning
@@ -31,103 +31,13 @@ const static std::string JOINT_TOPIC_NAME =
  * @param dt The upper limit of time from the previous point to achieve this one
  * @return A descartes trajectory point encapsulating a move to this pose
  */
-static inline descartes_core::TrajectoryPtPtr toDescartesPt(const Eigen::Affine3d& pose, double dt)
+descartes_core::TrajectoryPtPtr toDescartesBlendPt(const Eigen::Affine3d& pose, double dt)
 {
   using namespace descartes_trajectory;
   using namespace descartes_core;
   const TimingConstraint tm(dt);
   return boost::make_shared<AxialSymmetricPt>(pose, BLENDING_ANGLE_DISCRETIZATION,
                                               AxialSymmetricPt::Z_AXIS, tm);
-}
-
-struct ConnectingPath
-{
-  EigenSTL::vector_Affine3d depart;
-  EigenSTL::vector_Affine3d approach;
-};
-
-static std::vector<ConnectingPath>
-generateTransitions(const std::vector<geometry_msgs::PoseArray>& segments,
-                    const double traverse_height)
-{
-  const static double APPROACH_STEP_SIZE = 0.02; // m
-  const int steps = std::ceil(traverse_height / APPROACH_STEP_SIZE);
-
-  std::vector<ConnectingPath> result;
-
-  // Loop over every connecting edge
-  for (std::size_t i = 0; i < segments.size(); ++i)
-  {
-    const auto& start_pose = segments[i].poses.front(); // First point in this segment
-    const auto& end_pose = segments[i].poses.back();    // Last point in this segment
-
-    Eigen::Affine3d e_start, e_end;
-    tf::poseMsgToEigen(start_pose, e_start);
-    tf::poseMsgToEigen(end_pose, e_end);
-
-    // Each connecting segment has a retraction from 'from_pose'
-    // And an approach to 'to_pose'
-    auto approach = linearMoveZ(e_start, APPROACH_STEP_SIZE, steps);
-    auto depart = linearMoveZ(e_end, APPROACH_STEP_SIZE, steps);
-    std::reverse(approach.begin(), approach.end()); // we flip the 'to' path to keep the time ordering of the path
-
-    ConnectingPath c;
-    c.depart = std::move(depart);
-    c.approach = std::move(approach);
-    result.push_back(c);
-  }
-  return result;
-}
-
-/**
- * @brief transforms a sequence of pose-arrays, each representing a single 'segment' of a
- * process path into a Descartes specific format. This function also adds transitions between
- * segments.
- * @param segments Sequence of poses (relative to the world space of blending robot model)
- * @param params Surface blending parameters, including info such as traversal speed
- * @return The input trajectory encoded in Descartes points
- */
-static godel_process_planning::DescartesTraj
-toDescartesTraj(const std::vector<geometry_msgs::PoseArray>& segments,
-                const godel_msgs::BlendingPlanParameters& params)
-{
-  auto transitions = generateTransitions(segments, params.safe_traverse_height);
-
-  DescartesTraj traj;
-  Eigen::Affine3d last_pose = createNominalTransform(segments.front().poses.front());
-
-  // Convert pose arrays to Eigen types
-  auto eigen_segments = toEigenArrays(segments);
-
-  // Inline function for adding a sequence of motions
-  auto add_segment = [&traj, &last_pose, params] (const EigenSTL::vector_Affine3d& poses, bool free_last)
-  {
-    // Create Descartes trajectory for the segment path
-    for (std::size_t j = 0; j < poses.size(); ++j)
-    {
-      Eigen::Affine3d this_pose = createNominalTransform(poses[j]);
-      // O(1) jerky - may need to revisit this time parameterization later. This at least allows
-      // Descartes to perform some optimizations in its graph serach.
-      double dt = (this_pose.translation() - last_pose.translation()).norm() / params.traverse_spd;
-      if (j == poses.size() - 1 && free_last)
-      {
-        dt = 0.0;
-      }
-      traj.push_back(toDescartesPt(this_pose, dt));
-      last_pose = this_pose;
-    }
-  };
-
-  for (std::size_t i = 0; i < segments.size(); ++i)
-  {
-    add_segment(transitions[i].approach, true);
-
-    add_segment(eigen_segments[i], false);
-
-    add_segment(transitions[i].depart, false);
-  } // end segments
-
-  return traj;
 }
 
 /**
@@ -163,8 +73,11 @@ bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlannin
   // Transform process path from geometry msgs to descartes points
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
 
-  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params);
+  const static double LINEAR_DISCRETIZATION = 0.01; // meters
 
+  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.safe_traverse_height,
+                                                 req.params.traverse_spd, LINEAR_DISCRETIZATION,
+                                                 toDescartesBlendPt);
   if (generateMotionPlan(blend_model_, process_points, moveit_model_, blend_group_name_,
                          current_joints, res.plan))
   {

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -74,9 +74,16 @@ bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlannin
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
 
   const static double LINEAR_DISCRETIZATION = 0.01; // meters
+  const static double ANGULAR_DISCRETIZATION = 0.1; // radians
+  const static double RETRACT_DISTANCE = 0.05; // meters
 
-  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.safe_traverse_height,
-                                                 req.params.traverse_spd, LINEAR_DISCRETIZATION,
+  TransitionParameters transition_params;
+  transition_params.linear_disc = LINEAR_DISCRETIZATION;
+  transition_params.angular_disc = ANGULAR_DISCRETIZATION;
+  transition_params.retract_dist = RETRACT_DISTANCE;
+  transition_params.traverse_height = req.params.safe_traverse_height;
+
+  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.traverse_spd, transition_params,
                                                  toDescartesBlendPt);
   if (generateMotionPlan(blend_model_, process_points, moveit_model_, blend_group_name_,
                          current_joints, res.plan))

--- a/godel_process_planning/src/keyence_process_planning.cpp
+++ b/godel_process_planning/src/keyence_process_planning.cpp
@@ -70,10 +70,17 @@ bool ProcessPlanningManager::handleKeyencePlanning(godel_msgs::KeyenceProcessPla
 
   // Transform process path from geometry msgs to descartes points
   const static double LINEAR_DISCRETIZATION = 0.01; // meters
-  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.approach_distance,
-                                                 req.params.traverse_spd, LINEAR_DISCRETIZATION,
-                                                 toDescartesScanPt);
+  const static double ANGULAR_DISCRETIZATION = 0.1; // radians
+  const static double RETRACT_DISTANCE = 0.05; // meters
 
+  TransitionParameters transition_params;
+  transition_params.linear_disc = LINEAR_DISCRETIZATION;
+  transition_params.angular_disc = ANGULAR_DISCRETIZATION;
+  transition_params.retract_dist = RETRACT_DISTANCE;
+  transition_params.traverse_height = req.params.approach_distance;
+
+  DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.traverse_spd, transition_params,
+                                                 toDescartesScanPt);
   // Capture the current state of the robot
   std::vector<double> current_joints = getCurrentJointState(JOINT_TOPIC_NAME);
 

--- a/godel_process_planning/src/path_transitions.cpp
+++ b/godel_process_planning/src/path_transitions.cpp
@@ -1,0 +1,81 @@
+#include "path_transitions.h"
+
+std::vector<godel_process_planning::ConnectingPath>
+godel_process_planning::generateTransitions(const std::vector<geometry_msgs::PoseArray> &segments,
+                                            const double traverse_height, const double linear_discretization)
+{
+  const int steps = std::ceil(traverse_height / linear_discretization);
+
+  std::vector<ConnectingPath> result;
+
+  // Loop over every connecting edge
+  for (std::size_t i = 0; i < segments.size(); ++i)
+  {
+    const auto& start_pose = segments[i].poses.front(); // First point in this segment
+    const auto& end_pose = segments[i].poses.back();    // Last point in this segment
+
+    Eigen::Affine3d e_start, e_end;
+    tf::poseMsgToEigen(start_pose, e_start);
+    tf::poseMsgToEigen(end_pose, e_end);
+
+    // Each connecting segment has a retraction from 'from_pose'
+    // And an approach to 'to_pose'
+    auto approach = linearMoveZ(e_start, linear_discretization, steps);
+    auto depart = linearMoveZ(e_end, linear_discretization, steps);
+    std::reverse(approach.begin(), approach.end()); // we flip the 'to' path to keep the time ordering of the path
+
+    ConnectingPath c;
+    c.depart = std::move(depart);
+    c.approach = std::move(approach);
+    result.push_back(c);
+  }
+  return result;
+}
+
+using DescartesConversionFunc =
+  boost::function<descartes_core::TrajectoryPtPtr (const Eigen::Affine3d &, const double)>;
+
+godel_process_planning::DescartesTraj
+godel_process_planning::toDescartesTraj(const std::vector<geometry_msgs::PoseArray> &segments,
+                                        const double traverse_height, const double process_speed,
+                                        const double linear_discretization, DescartesConversionFunc conversion_fn)
+{
+  auto transitions = generateTransitions(segments, traverse_height, linear_discretization);
+
+  DescartesTraj traj;
+  Eigen::Affine3d last_pose = createNominalTransform(segments.front().poses.front());
+
+  // Convert pose arrays to Eigen types
+  auto eigen_segments = toEigenArrays(segments);
+
+  // Inline function for adding a sequence of motions
+  auto add_segment = [&traj, &last_pose, process_speed, conversion_fn]
+                     (const EigenSTL::vector_Affine3d& poses, bool free_last)
+  {
+    // Create Descartes trajectory for the segment path
+    for (std::size_t j = 0; j < poses.size(); ++j)
+    {
+      Eigen::Affine3d this_pose = createNominalTransform(poses[j]);
+      // O(1) jerky - may need to revisit this time parameterization later. This at least allows
+      // Descartes to perform some optimizations in its graph serach.
+      double dt = (this_pose.translation() - last_pose.translation()).norm() / process_speed;
+      if (j == poses.size() - 1 && free_last)
+      {
+        dt = 0.0;
+      }
+      traj.push_back( conversion_fn(this_pose, dt) );
+      last_pose = this_pose;
+    }
+  };
+
+  for (std::size_t i = 0; i < segments.size(); ++i)
+  {
+    add_segment(transitions[i].approach, true);
+
+    add_segment(eigen_segments[i], false);
+
+    add_segment(transitions[i].depart, false);
+  } // end segments
+
+  return traj;
+}

--- a/godel_process_planning/src/path_transitions.h
+++ b/godel_process_planning/src/path_transitions.h
@@ -15,8 +15,16 @@ struct ConnectingPath
   EigenSTL::vector_Affine3d approach;
 };
 
+struct TransitionParameters
+{
+  double linear_disc;
+  double angular_disc;
+  double traverse_height;
+  double retract_dist;
+};
+
 std::vector<ConnectingPath> generateTransitions(const std::vector<geometry_msgs::PoseArray>& segments,
-                                                const double traverse_height, const double linear_discretization);
+                                                const TransitionParameters& params);
 
 /**
  * @brief transforms a sequence of pose-arrays, each representing a single 'segment' of a
@@ -33,8 +41,7 @@ std::vector<ConnectingPath> generateTransitions(const std::vector<geometry_msgs:
  */
 godel_process_planning::DescartesTraj
 toDescartesTraj(const std::vector<geometry_msgs::PoseArray>& segments,
-                const double traverse_height, const double process_speed,
-                const double linear_discretization,
+                const double process_speed, const TransitionParameters& transition_params,
                 boost::function<descartes_core::TrajectoryPtPtr(const Eigen::Affine3d&, const double)> conversion_fn);
 
 

--- a/godel_process_planning/src/path_transitions.h
+++ b/godel_process_planning/src/path_transitions.h
@@ -1,0 +1,43 @@
+#ifndef GODEL_PROCESS_PLANNING_PATH_TRANSITIONS_H
+#define GODEL_PROCESS_PLANNING_PATH_TRANSITIONS_H
+
+#include "common_utils.h"
+#include <godel_msgs/BlendingPlanParameters.h>
+#include "eigen_conversions/eigen_msg.h"
+
+
+namespace godel_process_planning
+{
+
+struct ConnectingPath
+{
+  EigenSTL::vector_Affine3d depart;
+  EigenSTL::vector_Affine3d approach;
+};
+
+std::vector<ConnectingPath> generateTransitions(const std::vector<geometry_msgs::PoseArray>& segments,
+                                                const double traverse_height, const double linear_discretization);
+
+/**
+ * @brief transforms a sequence of pose-arrays, each representing a single 'segment' of a
+ * process path into a Descartes specific format. This function also adds transitions between
+ * segments.
+ * @param segments Sequence of poses (relative to the world space of blending robot model)
+ * @param traverse_height The height in meters from the surface of the part to move to before
+ *        moving to the next segment start
+ * @param process_speed The point to point difference in speed
+ * @param linear_discretization The distance (meters) between points in the connecting paths
+ * @param conversion_fn A function that creates a Descartes process point of whatever type your
+ *        process (e.g. blending or scanning) requires
+ * @return The input trajectory encoded in Descartes points
+ */
+godel_process_planning::DescartesTraj
+toDescartesTraj(const std::vector<geometry_msgs::PoseArray>& segments,
+                const double traverse_height, const double process_speed,
+                const double linear_discretization,
+                boost::function<descartes_core::TrajectoryPtPtr(const Eigen::Affine3d&, const double)> conversion_fn);
+
+
+}
+
+#endif // GODEL_PROCESS_PLANNING_PATH_TRANSITIONS_H


### PR DESCRIPTION
Changes path transitions to happen at the `safe traverse height`. The tool retracts from the part a small distance, goes straight upward in workspace coordinates to a specific Z-height, and then interpolates to the drop position for the next segment.

Built on top of #174 