### PR TITLE
Debug Switch for godel_surface_detection

### DIFF
--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
@@ -7,7 +7,8 @@
   <arg name="sim_laser" default="true"/>
   <arg name="laser_ip" unless="$(arg sim_laser)" default="192.168.32.50"/>
   <arg name="robot_model_plugin" default="abb_irb2400_descartes/AbbIrb2400RobotModel"/>
-  <arg name="debug_mode" default="false"/>
+  <arg name="debug_rviz" default="false"/>
+  <arg name="debug_core" default="false"/> <!--Brings up the surface blending service in debug mode-->
 
   <!-- Brings up action interface for simple trajectory execution - used by laser scanner process execution -->
   <node name="path_execution_service" pkg="godel_path_execution" type="path_execution_service_node"/>
@@ -41,6 +42,7 @@
        for both the blender and the laser scanner. -->
   <include file="$(find godel_surface_detection)/launch/godel_core.launch">
     <arg name="config_path" value="$(find godel_irb2400_support)/config"/>
+    <arg name="debug" value="$(arg debug_core)"/>
   </include>
 
   <!-- If the user specifies a 'fake' sensor, publish fake data clouds -->
@@ -76,12 +78,11 @@
     </node>
   </group>
   
-  <group if="$(arg debug_mode)">
+  <!-- rviz w/ specified configuration -->
+  <group if="$(arg debug_rviz)">
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_irb2400_support)/rviz/irb2400_blending.rviz" output="screen" launch-prefix="xterm -e gdb --args" required="true"/>
   </group>
-
-  <!-- rviz w/ specified configuration -->
-  <group unless="$(arg debug_mode)">
+  <group unless="$(arg debug_rviz)">
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find godel_irb2400_support)/rviz/irb2400_blending.rviz" output="screen" launch-prefix="nice" required="true"/>
   </group>
 

--- a/godel_surface_detection/launch/godel_core.launch
+++ b/godel_surface_detection/launch/godel_core.launch
@@ -3,8 +3,13 @@
   <!-- arguments -->
   <arg name="config_path"/>
 
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args" />
+
     <!-- surface detection service -->
-  <node name="surface_blending_service" pkg="godel_surface_detection" type="surface_blending_service" output="screen" required="true">
+  <node name="surface_blending_service" pkg="godel_surface_detection" type="surface_blending_service" output="screen"
+        required="true" launch-prefix="$(arg launch_prefix)">
     <rosparam command="load" file="$(arg config_path)/robot_scan.yaml"/>
     <rosparam command="load" file="$(arg config_path)/blending_plan.yaml"/>
     <rosparam command="load" file="$(arg config_path)/surface_detection.yaml"/>


### PR DESCRIPTION
Small quality of life improvement. Removes `debug_mode` arg and adds `debug_rviz` and `debug_core`. The latter launches the surface detection server under gdb.