### PR TITLE
Used OMP to Parallelize the Boundary Search

### DIFF
--- a/godel_surface_detection/CMakeLists.txt
+++ b/godel_surface_detection/CMakeLists.txt
@@ -82,6 +82,10 @@ add_executable(surface_blending_service  src/services/surface_blending_service.c
 target_link_libraries(surface_blending_service ${PROJECT_NAME})
 add_dependencies(surface_blending_service godel_msgs_generate_messages_cpp)
 
+# Surface segmentation stand alone node
+add_executable(surface_segmentation_node src/nodes/boundary_test_node.cpp)
+target_link_libraries(surface_segmentation_node ${PROJECT_NAME})
+
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/godel_surface_detection/CMakeLists.txt
+++ b/godel_surface_detection/CMakeLists.txt
@@ -20,7 +20,16 @@ find_package(catkin REQUIRED COMPONENTS
   meshing_plugins_base
   path_planning_plugins_base
 )
+
 find_package(Boost REQUIRED COMPONENTS system)
+
+
+find_package(OpenMP REQUIRED)
+if(OPENMP_FOUND)
+  message(STATUS "OPENMP FOUND")
+  set(OpenMP_FLAGS ${OpenMP_CXX_FLAGS})  # or if you use C: ${OpenMP_C_FLAGS}
+  set(OpenMP_LIBS gomp)
+endif()
 
 catkin_package(
   INCLUDE_DIRS 
@@ -65,6 +74,8 @@ add_library(${PROJECT_NAME}
   src/services/trajectory_library.cpp
   src/utils/mesh_conversions.cpp)
 
+target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_FLAGS})
+
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} yaml-cpp)
 add_dependencies(${PROJECT_NAME} godel_msgs_generate_messages_cpp)
 
@@ -81,6 +92,7 @@ add_executable(surface_blending_service  src/services/surface_blending_service.c
                                          src/services/blending_service_path_generation.cpp)
 target_link_libraries(surface_blending_service ${PROJECT_NAME})
 add_dependencies(surface_blending_service godel_msgs_generate_messages_cpp)
+target_compile_options(surface_blending_service PRIVATE ${OpenMP_FLAGS})
 
 # Surface segmentation stand alone node
 add_executable(surface_segmentation_node src/nodes/boundary_test_node.cpp)

--- a/godel_surface_detection/include/segmentation/surface_segmentation.h
+++ b/godel_surface_detection/include/segmentation/surface_segmentation.h
@@ -9,7 +9,6 @@
 #include <pcl/geometry/quad_mesh.h>
 #include <pcl/geometry/polygon_mesh.h>
 #include <pcl/geometry/mesh_conversion.h>
-#include <pcl/features/boundary.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/io/ply_io.h>
 #include <pcl/io/vtk_io.h>

--- a/godel_surface_detection/src/nodes/boundary_test_node.cpp
+++ b/godel_surface_detection/src/nodes/boundary_test_node.cpp
@@ -1,12 +1,10 @@
 #include <segmentation/surface_segmentation.h>
 #include <ros/ros.h>
 
-
 /*
- * A stand-alone node that uses Godel's current surface segmentation algorithms
- * for the purposes of testing and profiling
+ * A stand-alone node for testing Godel's "SurfaceSegmentation" class w/o the
+ * infrastructure required for the entire system.
  */
-
 
 static pcl::PointCloud<pcl::PointXYZRGB>::Ptr
 computeBoundaryCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud)

--- a/godel_surface_detection/src/nodes/boundary_test_node.cpp
+++ b/godel_surface_detection/src/nodes/boundary_test_node.cpp
@@ -1,0 +1,72 @@
+#include <segmentation/surface_segmentation.h>
+#include <ros/ros.h>
+
+
+/*
+ * A stand-alone node that uses Godel's current surface segmentation algorithms
+ * for the purposes of testing and profiling
+ */
+
+
+static pcl::PointCloud<pcl::PointXYZRGB>::Ptr
+computeBoundaryCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud)
+{
+  const static double SEGMENTATION_SEARCH_RADIUS = 0.03; // 3cm
+
+  SurfaceSegmentation segmenter (cloud);
+  segmenter.setSearchRadius(SEGMENTATION_SEARCH_RADIUS);
+
+  pcl::PointCloud<pcl::Boundary>::Ptr boundary_ptr (new pcl::PointCloud<pcl::Boundary>());
+  segmenter.getBoundaryCloud(boundary_ptr);
+
+  // Return data structures
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr boundary_cloud_ptr(new pcl::PointCloud<pcl::PointXYZRGB>());
+  pcl::IndicesPtr boundary_idx(new std::vector<int>());
+
+  // Populate color cloud
+  int k=0;
+  for(const auto& pt : boundary_ptr->points)
+  {
+    if(pt.boundary_point)
+    {
+      boundary_cloud_ptr->points.push_back(cloud->points[k]);
+      boundary_idx->push_back(k);
+    }
+    k++;
+  }
+
+  boundary_cloud_ptr->width = 1;
+  boundary_cloud_ptr->height = boundary_cloud_ptr->points.size();
+
+  return boundary_cloud_ptr;
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "boundary_test_node");
+  ros::NodeHandle pnh ("~");
+
+  std::string filename;
+  if (!pnh.getParam("filename", filename))
+  {
+    ROS_ERROR("Node requires user to set private parameter 'filename'");
+    return 1;
+  }
+
+  auto cloud = boost::make_shared<pcl::PointCloud<pcl::PointXYZRGB>>();
+
+  if (pcl::io::loadPCDFile(filename, *cloud) < 0)
+  {
+    ROS_ERROR("Could not load cloud file: %s", filename.c_str());
+    return 2;
+  }
+
+  ROS_INFO("Starting boundary extraction routine...");
+  auto start_tm = ros::Time::now();
+  auto boundary_cloud = computeBoundaryCloud(cloud);
+  auto finish_tm = ros::Time::now();
+  ROS_INFO("Boundary extract completed after %f seconds.", (finish_tm - start_tm).toSec());
+
+  pcl::io::savePCDFile("boundary.pcd", *boundary_cloud);
+  return 0;
+}

--- a/godel_surface_detection/src/segmentation/parallel_boundary.h
+++ b/godel_surface_detection/src/segmentation/parallel_boundary.h
@@ -1,0 +1,185 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *  
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#ifndef PCL_PARALLEL_BOUNDARY_H_
+#define PCL_PARALLEL_BOUNDARY_H_
+
+#include <pcl/features/eigen.h>
+#include <pcl/features/feature.h>
+
+namespace pcl
+{
+  /** \brief BoundaryEstimation estimates whether a set of points is lying on surface boundaries using an angle
+    * criterion. The code makes use of the estimated surface normals at each point in the input dataset.
+    *
+    * Here's an example for estimating boundary points for a PointXYZ point cloud:
+    * \code
+    * pcl::PointCloud<pcl::PointXYZ>::Ptr cloud (new pcl::PointCloud<pcl::PointXYZ>);
+    * // fill in the cloud data here
+    * 
+    * pcl::PointCloud<pcl::Normal>::Ptr normals (new pcl::PointCloud<pcl::Normal>);
+    * // estimate normals and fill in \a normals
+    *
+    * pcl::PointCloud<pcl::Boundary> boundaries;
+    * pcl::BoundaryEstimation<pcl::PointXYZ, pcl::Normal, pcl::Boundary> est;
+    * est.setInputCloud (cloud);
+    * est.setInputNormals (normals);
+    * est.setRadiusSearch (0.02);   // 2cm radius
+    * est.setSearchMethod (typename pcl::search::KdTree<PointXYZ>::Ptr (new pcl::search::KdTree<PointXYZ>)
+    * est.compute (boundaries);
+    * \endcode
+    *
+    * \attention 
+    * The convention for Boundary features is:
+    *   - if a query point's nearest neighbors cannot be estimated, the boundary feature will be set to NaN 
+    *     (not a number)
+    *   - it is impossible to estimate a boundary property for a point that
+    *     doesn't have finite 3D coordinates. Therefore, any point that contains
+    *     NaN data on x, y, or z, will have its boundary feature property set to NaN.
+    *
+    * \author Radu B. Rusu
+    * \ingroup features
+    */
+  template <typename PointInT, typename PointNT, typename PointOutT>
+  class ParallelBoundaryEstimation: public FeatureFromNormals<PointInT, PointNT, PointOutT>
+  {
+    public:
+      typedef boost::shared_ptr<ParallelBoundaryEstimation<PointInT, PointNT, PointOutT> > Ptr;
+      typedef boost::shared_ptr<const ParallelBoundaryEstimation<PointInT, PointNT, PointOutT> > ConstPtr;
+
+      using Feature<PointInT, PointOutT>::feature_name_;
+      using Feature<PointInT, PointOutT>::getClassName;
+      using Feature<PointInT, PointOutT>::input_;
+      using Feature<PointInT, PointOutT>::indices_;
+      using Feature<PointInT, PointOutT>::k_;
+      using Feature<PointInT, PointOutT>::tree_;
+      using Feature<PointInT, PointOutT>::search_radius_;
+      using Feature<PointInT, PointOutT>::search_parameter_;
+      using Feature<PointInT, PointOutT>::surface_;
+      using FeatureFromNormals<PointInT, PointNT, PointOutT>::normals_;
+
+      typedef typename Feature<PointInT, PointOutT>::PointCloudOut PointCloudOut;
+
+    public:
+      /** \brief Empty constructor. 
+        * The angular threshold \a angle_threshold_ is set to M_PI / 2.0
+        */
+      ParallelBoundaryEstimation () : angle_threshold_ (static_cast<float> (M_PI) / 2.0f)
+      {
+        feature_name_ = "ParallelBoundaryEstimation";
+      };
+
+     /** \brief Check whether a point is a boundary point in a planar patch of projected points given by indices.
+        * \note A coordinate system u-v-n must be computed a-priori using \a getCoordinateSystemOnPlane
+        * \param[in] cloud a pointer to the input point cloud
+        * \param[in] q_idx the index of the query point in \a cloud
+        * \param[in] indices the estimated point neighbors of the query point
+        * \param[in] u the u direction
+        * \param[in] v the v direction
+        * \param[in] angle_threshold the threshold angle (default \f$\pi / 2.0\f$)
+        */
+      bool 
+      isBoundaryPoint (const pcl::PointCloud<PointInT> &cloud, 
+                       int q_idx, const std::vector<int> &indices, 
+                       const Eigen::Vector4f &u, const Eigen::Vector4f &v, const float angle_threshold);
+
+      /** \brief Check whether a point is a boundary point in a planar patch of projected points given by indices.
+        * \note A coordinate system u-v-n must be computed a-priori using \a getCoordinateSystemOnPlane
+        * \param[in] cloud a pointer to the input point cloud
+        * \param[in] q_point a pointer to the querry point
+        * \param[in] indices the estimated point neighbors of the query point
+        * \param[in] u the u direction
+        * \param[in] v the v direction
+        * \param[in] angle_threshold the threshold angle (default \f$\pi / 2.0\f$)
+        */
+      bool 
+      isBoundaryPoint (const pcl::PointCloud<PointInT> &cloud, 
+                       const PointInT &q_point, 
+                       const std::vector<int> &indices, 
+                       const Eigen::Vector4f &u, const Eigen::Vector4f &v, const float angle_threshold);
+
+      /** \brief Set the decision boundary (angle threshold) that marks points as boundary or regular. 
+        * (default \f$\pi / 2.0\f$) 
+        * \param[in] angle the angle threshold
+        */
+      inline void
+      setAngleThreshold (float angle)
+      {
+        angle_threshold_ = angle;
+      }
+
+      /** \brief Get the decision boundary (angle threshold) as set by the user. */
+      inline float
+      getAngleThreshold ()
+      {
+        return (angle_threshold_);
+      }
+
+      /** \brief Get a u-v-n coordinate system that lies on a plane defined by its normal
+        * \param[in] p_coeff the plane coefficients (containing the plane normal)
+        * \param[out] u the resultant u direction
+        * \param[out] v the resultant v direction
+        */
+      inline void 
+      getCoordinateSystemOnPlane (const PointNT &p_coeff, 
+                                  Eigen::Vector4f &u, Eigen::Vector4f &v)
+      {
+        pcl::Vector4fMapConst p_coeff_v = p_coeff.getNormalVector4fMap ();
+        v = p_coeff_v.unitOrthogonal ();
+        u = p_coeff_v.cross3 (v);
+      }
+
+    protected:
+      /** \brief Estimate whether a set of points is lying on surface boundaries using an angle criterion for all points
+        * given in <setInputCloud (), setIndices ()> using the surface in setSearchSurface () and the spatial locator in
+        * setSearchMethod ()
+        * \param[out] output the resultant point cloud model dataset that contains boundary point estimates
+        */
+      void 
+      computeFeature (PointCloudOut &output);
+
+      /** \brief The decision boundary (angle threshold) that marks points as boundary or regular. (default \f$\pi / 2.0\f$) */
+      float angle_threshold_;
+  };
+}
+
+#include "parallel_boundary.hpp"
+
+#endif  //#ifndef PCL_PARALLEL_BOUNDARY_H_

--- a/godel_surface_detection/src/segmentation/parallel_boundary.hpp
+++ b/godel_surface_detection/src/segmentation/parallel_boundary.hpp
@@ -98,19 +98,15 @@ pcl::ParallelBoundaryEstimation<PointInT, PointNT, PointOutT>::isBoundaryPoint (
   for (size_t i = 0; i < angles.size () - 1; ++i)
   {
     dif = angles[i + 1] - angles[i];
-    if (max_dif < dif)
-      max_dif = dif;
+    if (dif > angle_threshold)
+      return true;
   }
   // Get the angle difference between the last and the first
   dif = 2 * static_cast<float> (M_PI) - angles[angles.size () - 1] + angles[0];
-  if (max_dif < dif)
-    max_dif = dif;
+  if (dif > angle_threshold)
+    return true;
 
-  // Check results
-  if (max_dif > angle_threshold)
-    return (true);
-  else
-    return (false);
+  return (false);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/godel_surface_detection/src/segmentation/parallel_boundary.hpp
+++ b/godel_surface_detection/src/segmentation/parallel_boundary.hpp
@@ -1,0 +1,183 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id$
+ *
+ */
+
+#ifndef PCL_FEATURES_IMPL_PARALLEL_BOUNDARY_H_
+#define PCL_FEATURES_IMPL_PARALLEL_BOUNDARY_H_
+
+#include "parallel_boundary.h"
+#include <ros/console.h>
+#include <cfloat>
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT, typename PointNT, typename PointOutT> bool
+pcl::ParallelBoundaryEstimation<PointInT, PointNT, PointOutT>::isBoundaryPoint (
+      const pcl::PointCloud<PointInT> &cloud, int q_idx, 
+      const std::vector<int> &indices, 
+      const Eigen::Vector4f &u, const Eigen::Vector4f &v, 
+      const float angle_threshold)
+{
+  return (isBoundaryPoint (cloud, cloud.points[q_idx], indices, u, v, angle_threshold));
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT, typename PointNT, typename PointOutT> bool
+pcl::ParallelBoundaryEstimation<PointInT, PointNT, PointOutT>::isBoundaryPoint (
+      const pcl::PointCloud<PointInT> &cloud, const PointInT &q_point, 
+      const std::vector<int> &indices, 
+      const Eigen::Vector4f &u, const Eigen::Vector4f &v, 
+      const float angle_threshold)
+{
+  if (indices.size () < 3)
+    return (false);
+
+  if (!pcl_isfinite (q_point.x) || !pcl_isfinite (q_point.y) || !pcl_isfinite (q_point.z))
+    return (false);
+
+  // Compute the angles between each neighboring point and the query point itself
+  std::vector<float> angles (indices.size ());
+  float max_dif = FLT_MIN, dif;
+  int cp = 0;
+
+  for (size_t i = 0; i < indices.size (); ++i)
+  {
+    if (!pcl_isfinite (cloud.points[indices[i]].x) || 
+        !pcl_isfinite (cloud.points[indices[i]].y) || 
+        !pcl_isfinite (cloud.points[indices[i]].z))
+      continue;
+
+    Eigen::Vector4f delta = cloud.points[indices[i]].getVector4fMap () - q_point.getVector4fMap ();
+    if (delta == Eigen::Vector4f::Zero())
+      continue;
+
+    angles[cp++] = atan2f (v.dot (delta), u.dot (delta)); // the angles are fine between -PI and PI too
+  }
+  if (cp == 0)
+    return (false);
+
+  angles.resize (cp);
+  std::sort (angles.begin (), angles.end ());
+
+  // Compute the maximal angle difference between two consecutive angles
+  for (size_t i = 0; i < angles.size () - 1; ++i)
+  {
+    dif = angles[i + 1] - angles[i];
+    if (max_dif < dif)
+      max_dif = dif;
+  }
+  // Get the angle difference between the last and the first
+  dif = 2 * static_cast<float> (M_PI) - angles[angles.size () - 1] + angles[0];
+  if (max_dif < dif)
+    max_dif = dif;
+
+  // Check results
+  if (max_dif > angle_threshold)
+    return (true);
+  else
+    return (false);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+template <typename PointInT, typename PointNT, typename PointOutT> void
+pcl::ParallelBoundaryEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut &output)
+{
+  // Save a few cycles by not checking every point for NaN/Inf values if the cloud is set to dense
+  if (input_->is_dense)
+  {
+    // Iterating over the entire index vector
+    #pragma omp parallel for
+    for (size_t idx = 0; idx < indices_->size (); ++idx)
+    {
+      std::vector<int> nn_indices (k_);
+      std::vector<float> nn_dists (k_);
+      if (this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
+      {
+        output.points[idx].boundary_point = std::numeric_limits<uint8_t>::quiet_NaN ();
+        continue;
+      }
+      Eigen::Vector4f u = Eigen::Vector4f::Zero (), v = Eigen::Vector4f::Zero ();
+      // Obtain a coordinate system on the least-squares plane
+      //v = normals_->points[(*indices_)[idx]].getNormalVector4fMap ().unitOrthogonal ();
+      //u = normals_->points[(*indices_)[idx]].getNormalVector4fMap ().cross3 (v);
+      getCoordinateSystemOnPlane (normals_->points[(*indices_)[idx]], u, v);
+
+      // Estimate whether the point is lying on a boundary surface or not
+      output.points[idx].boundary_point = isBoundaryPoint (*surface_, input_->points[(*indices_)[idx]], nn_indices, u, v, angle_threshold_);
+    }
+  }
+  else
+  {
+    // Iterating over the entire index vector
+    #pragma omp parallel for
+    for (size_t idx = 0; idx < indices_->size (); ++idx)
+    {
+      std::vector<int> nn_indices (k_);
+      std::vector<float> nn_dists (k_);
+
+      if (!isFinite ((*input_)[(*indices_)[idx]]) ||
+          this->searchForNeighbors ((*indices_)[idx], search_parameter_, nn_indices, nn_dists) == 0)
+      {
+        output.points[idx].boundary_point = std::numeric_limits<uint8_t>::quiet_NaN ();
+        continue;
+      }
+      Eigen::Vector4f u = Eigen::Vector4f::Zero (), v = Eigen::Vector4f::Zero ();
+      // Obtain a coordinate system on the least-squares plane
+      //v = normals_->points[(*indices_)[idx]].getNormalVector4fMap ().unitOrthogonal ();
+      //u = normals_->points[(*indices_)[idx]].getNormalVector4fMap ().cross3 (v);
+      getCoordinateSystemOnPlane (normals_->points[(*indices_)[idx]], u, v);
+
+      // Estimate whether the point is lying on a boundary surface or not
+      output.points[idx].boundary_point = isBoundaryPoint (*surface_, input_->points[(*indices_)[idx]], nn_indices, u, v, angle_threshold_);
+    }
+  }
+
+  // Do the 'is_dense' checks after the search is done
+  output.is_dense = true;
+  for (std::size_t i = 0; i < output.points.size(); ++i)
+  {
+    if (pcl_isnan(output.points[i].boundary_point))
+    {
+      output.is_dense = false;
+      break;
+    }
+  }
+} // end of computeFeatures
+
+#endif    // PCL_FEATURES_IMPL_PARALLEL_BOUNDARY_H_
+

--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -4,6 +4,8 @@
 #include <ros/io.h>
 #include <thread>
 
+// Custom boundary estimation
+#include "parallel_boundary.h"
 
 /** @brief default constructor */
 SurfaceSegmentation::SurfaceSegmentation()
@@ -70,7 +72,7 @@ void SurfaceSegmentation::getBoundaryCloud(pcl::PointCloud<pcl::Boundary>::Ptr &
   }
   else
   {
-    pcl::BoundaryEstimation<pcl::PointXYZRGB, pcl::Normal, pcl::Boundary> best;
+    pcl::ParallelBoundaryEstimation<pcl::PointXYZRGB, pcl::Normal, pcl::Boundary> best;
     best.setInputCloud(input_cloud_);
     best.setInputNormals(normals_);
     best.setRadiusSearch (radius_);


### PR DESCRIPTION
Copies the `pcl::BoundaryEstimation` class into our project, makes a few small changes, and uses OMP to parallelize the boundary search.

No significant changes from an algorithmic perspective. I may be able to speed up the boundary condition checking some, but I think there's also big wins available in the organization and searching of the point cloud. Using the `pcl::search::Octree` class got me a ~30% improvement. I'll make that a separate PR if needed.