### PR TITLE
Feature/decouple edge smoothing

### DIFF
--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
@@ -3,15 +3,15 @@
   <!-- arguments -->
   <arg name="sim_robot" default="true"/>
   <arg name="robot_ip" unless="$(arg sim_robot)" />
-  <arg name="sim_sensor" default="true"/>
   <arg name="sim_laser" default="true"/>
   <arg name="laser_ip" unless="$(arg sim_laser)" default="192.168.32.50"/>
   <arg name="robot_model_plugin" default="abb_irb2400_descartes/AbbIrb2400RobotModel"/>
+  <arg name="sim_sensor" default="true"/>
+  <arg name="real_pcd" default="false"/>
+  <arg name="pcd_location"/> <!-- path to pcd file of part -->
+  <arg name="pcd_frame" default="/base_link"/>
   <arg name="debug_rviz" default="false"/>
   <arg name="debug_core" default="false"/> <!--Brings up the surface blending service in debug mode-->
-  <arg name="real_pcd" default="false" if="$(arg sim_sensor)"/>
-  <arg name="pcd_location" if="$(arg real_pcd)"/> <!-- path to pcd file of part -->
-  <arg name="pcd_frame" default="/base_link" if="$(arg real_pcd)"/>
 
   <!-- Brings up action interface for simple trajectory execution - used by laser scanner process execution -->
   <node name="path_execution_service" pkg="godel_path_execution" type="path_execution_service_node"/>

--- a/godel_surface_detection/include/segmentation/surface_segmentation.h
+++ b/godel_surface_detection/include/segmentation/surface_segmentation.h
@@ -61,18 +61,42 @@ public:
   // search terms
   double radius_;
 
-  // Constructors/Destructors
+
+  //-------------------- Constructors/Destructors --------------------//
+
   SurfaceSegmentation();
   ~SurfaceSegmentation();
+  /**
+   * @brief constructor that sets the background cloud, also initializes the KdTree for searching
+   * @param bg_cloud the set of points defining the background
+   */
   SurfaceSegmentation(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud);
 
-  // Clouds
+
+  //-------------------- Clouds --------------------//
+
+  /**
+   * @brief sets the background cloud, replaces whatever points exists if any
+   * @param background_cloud the cloud representing the background
+   */
   void setInputCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud);
+
+  /**
+   * @brief adds new points to the background, and reinitializes the kd_tree for searching
+   * @param bg_cloud additional background points
+   */
   void addCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud);
+
+  /**
+   * @brief creates a cloud from every point estimated to be on the boundary of input_cloud_
+   * @return a boundary point cloud
+   */
   void getBoundaryCloud(pcl::PointCloud<pcl::Boundary>::Ptr &boundary_cloud);
   void getSurfaceClouds(std::vector<pcl::PointCloud<pcl::PointXYZRGB>::Ptr> &surface_clouds);
 
-  // Computations
+
+  //-------------------- Computations --------------------//
+
   std::vector <pcl::PointIndices> computeSegments(pcl::PointCloud<pcl::PointXYZRGB>::Ptr &colored_cloud);
   Mesh computeMesh();
   std::pair<int, int> getNextUnused(std::vector< std::pair<int,int> > used);
@@ -80,19 +104,34 @@ public:
   void setSearchRadius(double radius);
   double getSearchRadius();
 
-  // Smoothing
+
+  //-------------------- Smoothing --------------------//
   void smoothVector(const std::vector<double> &x_in, std::vector<double> &x_out, const std::vector<double> &coef);
+
+  /**
+   * @brief SurfaceSegmentation::smoothPointNormal Uses a running weighted average (look-ahead and look-behind
+   *        to smooth a vector of point normals. Default values for position and orientation smoother length were
+   *        empirically derived and should be changed to best suit the user's application.
+   * @param pts_in Input point vector
+   * @param pts_out Destination for smoothed point vector
+   * @param p_length Length of position smoother. Increasing this leads to smoother, less accurate edges.
+   * @param w_length Length of orienation smoother. Increasing leads to less variation in edge point normal vectors.
+   */
   void smoothPointNormal(std::vector<pcl::PointNormal> &pts_in, std::vector<pcl::PointNormal> &pts_out, int p_length,
                          int w_length);
 
-  // Misc
+
+  //-------------------- Misc --------------------//
 
   void getBoundaryTrajectory(std::vector<pcl::IndicesPtr> &boundaries,
                              int sb,
                              std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>> &poses);
 
 private:
+  /** @brief remove any NAN points, otherwise many algorithms fail */
   void removeNans();
+
+  /** @brief compute the normals and store in normals_, this is requried for both segmentation and meshing*/
   void computeNormals();
 
   pcl::PointCloud<pcl::Normal>::Ptr normals_;

--- a/godel_surface_detection/include/segmentation/surface_segmentation.h
+++ b/godel_surface_detection/include/segmentation/surface_segmentation.h
@@ -82,7 +82,8 @@ public:
 
   // Smoothing
   void smoothVector(const std::vector<double> &x_in, std::vector<double> &x_out, const std::vector<double> &coef);
-  void smoothPointNormal(std::vector<pcl::PointNormal> &pts_in, std::vector<pcl::PointNormal> &pts_out);
+  void smoothPointNormal(std::vector<pcl::PointNormal> &pts_in, std::vector<pcl::PointNormal> &pts_out, int p_length,
+                         int w_length);
 
   // Misc
 

--- a/godel_surface_detection/include/segmentation/surface_segmentation.h
+++ b/godel_surface_detection/include/segmentation/surface_segmentation.h
@@ -58,11 +58,6 @@ public:
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr input_cloud_;
   Mesh HEM_;
 
-  // smoothing filter
-  int num_coef_;
-  std::vector<double> coef_;
-  double gain_;
-
   // search terms
   double radius_;
 
@@ -86,8 +81,7 @@ public:
   double getSearchRadius();
 
   // Smoothing
-  bool setSmoothCoef(std::vector<double> &coef);
-  void smoothVector(std::vector<double>&x_in, std::vector<double> &x_out);
+  void smoothVector(const std::vector<double> &x_in, std::vector<double> &x_out, const std::vector<double> &coef);
   void smoothPointNormal(std::vector<pcl::PointNormal> &pts_in, std::vector<pcl::PointNormal> &pts_out);
 
   // Misc

--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -2,7 +2,6 @@
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <ros/io.h>
-#include <ros/node_handle.h>
 #include <thread>
 
 // Custom boundary estimation
@@ -242,12 +241,11 @@ void SurfaceSegmentation::smoothVector(const std::vector<double> &x_in,
     return;
   }
 
-  int gain = std::accumulate(smoothing_coef.begin(), smoothing_coef.end(), 0);
+  double gain = std::accumulate(smoothing_coef.begin(), smoothing_coef.end(), 0);
   int n = x_in.size();
 
   // initialize the filter using tail of x_in
   std::vector<double> xv;
-  xv.clear();
   for(int j = num_coef - 1; j >= 0; j--)
     xv.push_back(x_in[n-j-1]);
 

--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -7,7 +7,6 @@
 // Custom boundary estimation
 #include "parallel_boundary.h"
 
-/** @brief default constructor */
 SurfaceSegmentation::SurfaceSegmentation()
 {
   // initialize pointers to cloud members
@@ -15,7 +14,6 @@ SurfaceSegmentation::SurfaceSegmentation()
 }
 
 
-/** @brief distructor */
 SurfaceSegmentation::~SurfaceSegmentation()
 {
   input_cloud_ =  pcl::PointCloud<pcl::PointXYZRGB>::Ptr(new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -24,9 +22,6 @@ SurfaceSegmentation::~SurfaceSegmentation()
 }
 
 
-/** @brief constructor that sets the background cloud, also initializes the KdTree for searching
-@param bg_cloud the set of points defining the background
-*/
 SurfaceSegmentation::SurfaceSegmentation(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud)
 {
   input_cloud_ =  pcl::PointCloud<pcl::PointXYZRGB>::Ptr(new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -37,9 +32,6 @@ SurfaceSegmentation::SurfaceSegmentation(pcl::PointCloud<pcl::PointXYZRGB>::Ptr 
 }
 
 
-/** @brief sets the background cloud, replaces whatever points exists if any
-@param background_cloud the cloud representing the background
-*/
 void SurfaceSegmentation::setInputCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud)
 {
   input_cloud_->clear();
@@ -47,9 +39,6 @@ void SurfaceSegmentation::setInputCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr i
 }
 
 
-/** @brief adds new points to the background, and reinitializes the kd_tree for searching
-@param bg_cloud additional background points
-*/
 void SurfaceSegmentation::addCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud)
 {
   // push input_cloud onto icloud and then add, this strange sequence keeps ordering of clouds
@@ -61,9 +50,6 @@ void SurfaceSegmentation::addCloud(pcl::PointCloud<pcl::PointXYZRGB>::Ptr icloud
 }
 
 
-/** @brief creates a cloud from every point estimated to be on the boundary of input_cloud_
-@return a boundary point cloud
-*/
 void SurfaceSegmentation::getBoundaryCloud(pcl::PointCloud<pcl::Boundary>::Ptr &boundary_cloud)
 {
   if(normals_->points.size()==0 || input_cloud_->points.size() == 0)
@@ -270,15 +256,7 @@ void SurfaceSegmentation::smoothVector(const std::vector<double> &x_in,
   } // end for every point
 }
 
-/**
- * @brief SurfaceSegmentation::smoothPointNormal Uses a running weighted average (look-ahead and look-behind
- *        to smooth a vector of point normals. Default values for position and orientation smoother length were
- *        empirically derived and should be changed to best suit the user's application.
- * @param pts_in Input point vector
- * @param pts_out Destination for smoothed point vector
- * @param p_length Length of position smoother. Increasing this leads to smoother, less accurate edges.
- * @param w_length Length of orienation smoother. Increasing leads to less variation in edge point normal vectors.
- */
+
 void SurfaceSegmentation::smoothPointNormal(std::vector<pcl::PointNormal> &pts_in,
                                             std::vector<pcl::PointNormal> &pts_out,
                                             int p_length = 13,
@@ -423,7 +401,6 @@ void SurfaceSegmentation::getBoundaryTrajectory(std::vector<pcl::IndicesPtr> &bo
 }
 
 
-/** @brief remove any NAN points, otherwise many algorithms fail */
 void SurfaceSegmentation::removeNans()
 {
   std::vector<int> indices;
@@ -431,7 +408,6 @@ void SurfaceSegmentation::removeNans()
 }
 
 
-/** @brief compute the normals and store in normals_, this is requried for both segmentation and meshing*/
 void SurfaceSegmentation::computeNormals()
 {
   // Determine the number of available cores

--- a/godel_surface_detection/src/services/blending_service_path_generation.cpp
+++ b/godel_surface_detection/src/services/blending_service_path_generation.cpp
@@ -135,18 +135,6 @@ bool SurfaceBlendingService::generateEdgePath(godel_surface_detection::detection
   SurfaceSegmentation SS(surface);
 
   SS.setSearchRadius(SEGMENTATION_SEARCH_RADIUS);
-  std::vector<double> filt_coef;
-  filt_coef.push_back(1);
-  filt_coef.push_back(2);
-  filt_coef.push_back(3);
-  filt_coef.push_back(4);
-  filt_coef.push_back(5);
-  filt_coef.push_back(4);
-  filt_coef.push_back(3);
-  filt_coef.push_back(2);
-  filt_coef.push_back(1);
-
-  SS.setSmoothCoef(filt_coef);
   computeBoundaries(surface, SS, sorted_boundaries);
 
   ROS_INFO_STREAM("Boundaries Computed");


### PR DESCRIPTION
Based on #189. Separates smoothing for edge point position and edge point orientation and gives default values based on initial voxel grid sizing. Refactors a few Surface Segmentation member variables to local variables. Fixes bug in launch that required real_pcd argument to be set even when using real hardware.