### PR TITLE
Save DataCoordinator's Data

### DIFF
--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
@@ -12,9 +12,6 @@
   <arg name="pcd_frame" default="/base_link"/>
   <arg name="debug_rviz" default="false"/>
   <arg name="debug_core" default="false"/> <!--Brings up the surface blending service in debug mode-->
-  <arg name="real_pcd" default="false" if="$(arg sim_sensor)"/>
-  <arg name="pcd_location" if="$(arg real_pcd)"/> <!-- path to pcd file of part -->
-  <arg name="pcd_frame" default="/base_link" if="$(arg real_pcd)"/>
   <arg name="save_data" default="false" />
   <arg name="save_location" default="$(env HOME)/.ros/" />
 

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/launch/irb2400_blending.launch
@@ -12,6 +12,11 @@
   <arg name="pcd_frame" default="/base_link"/>
   <arg name="debug_rviz" default="false"/>
   <arg name="debug_core" default="false"/> <!--Brings up the surface blending service in debug mode-->
+  <arg name="real_pcd" default="false" if="$(arg sim_sensor)"/>
+  <arg name="pcd_location" if="$(arg real_pcd)"/> <!-- path to pcd file of part -->
+  <arg name="pcd_frame" default="/base_link" if="$(arg real_pcd)"/>
+  <arg name="save_data" default="false" />
+  <arg name="save_location" default="$(env HOME)/.ros/" />
 
   <!-- Brings up action interface for simple trajectory execution - used by laser scanner process execution -->
   <node name="path_execution_service" pkg="godel_path_execution" type="path_execution_service_node"/>
@@ -46,6 +51,8 @@
   <include file="$(find godel_surface_detection)/launch/godel_core.launch">
     <arg name="config_path" value="$(find godel_irb2400_support)/config"/>
     <arg name="debug" value="$(arg debug_core)"/>
+    <arg name="save_data" value="$(arg save_data)" />
+    <arg name="save_location" value="$(arg save_location)" />
   </include>
 
   <!-- If the user specifies a 'fake' sensor, publish fake data clouds -->

--- a/godel_surface_detection/include/coordination/data_coordinator.h
+++ b/godel_surface_detection/include/coordination/data_coordinator.h
@@ -1,10 +1,13 @@
 #ifndef DATA_COORDINATOR_H
 #define DATA_COORDINATOR_H
 
+#include <boost/filesystem.hpp>
+
 #include <pcl/PolygonMesh.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
-#include <geometry_msgs/PoseArray.h>
+
+#include "geometry_msgs/PoseArray.h"
 
 namespace godel_surface_detection
 {
@@ -38,7 +41,6 @@ namespace data
       std::vector<geometry_msgs::PoseArray> scan_poses_;
   };
 
-
   /**
    * @brief The CloudTypes enum for safety access to get/set cloud function
    */
@@ -59,14 +61,17 @@ namespace data
   private:
     int id_counter_;
     std::vector<SurfaceDetectionRecord> records_;
-
+    pcl::PointCloud<pcl::PointXYZRGB> process_cloud_;
     int getNextID();
     std::string printIds();
+    void saveRecord(boost::filesystem::path path);
+
 
   public:
     DataCoordinator();
     bool init();
     int addRecord(pcl::PointCloud<pcl::PointXYZRGB> input_cloud, pcl::PointCloud<pcl::PointXYZRGB> surface_cloud);
+    void setProcessCloud(pcl::PointCloud<pcl::PointXYZRGB> incloud);
     bool getCloud(CloudTypes cloud_type, int id, pcl::PointCloud<pcl::PointXYZRGB>& cloud);
     bool setSurfaceName(int id, const std::string& name);
     bool getSurfaceName(int id, std::string& name);
@@ -77,6 +82,7 @@ namespace data
     bool getEdgePosesByName(const std::string& edge_name, geometry_msgs::PoseArray& edge_poses);
     bool setPoses(PoseTypes pose_type, int id, const std::vector<geometry_msgs::PoseArray>& poses);
     bool getPoses(PoseTypes pose_type, int id, std::vector<geometry_msgs::PoseArray>& poses);
+    void asyncSaveRecord(boost::filesystem::path path);
   };
 } /* end namespace data */
 } /* end namespace godel_surface_detection */

--- a/godel_surface_detection/include/detection/surface_detection.h
+++ b/godel_surface_detection/include/detection/surface_detection.h
@@ -63,6 +63,8 @@ public:
   void get_surface_clouds(std::vector<CloudRGB::Ptr>& surfaces);
   void get_full_cloud(CloudRGB& cloud);
   void get_full_cloud(sensor_msgs::PointCloud2 cloud_msg);
+  void get_process_cloud(CloudRGB& cloud);
+  void get_process_cloud(sensor_msgs::PointCloud2 cloud_msg);
   void get_region_colored_cloud(CloudRGB& cloud);
   void get_region_colored_cloud(sensor_msgs::PointCloud2& cloud_msg);
 
@@ -80,7 +82,8 @@ private:
   std::default_random_engine random_engine_;
 
   // pcl members
-  pcl::PointCloud<pcl::PointXYZRGB>::Ptr full_cloud_ptr_;
+  CloudRGB::Ptr full_cloud_ptr_;
+  CloudRGB::Ptr process_cloud_ptr;
   CloudRGB::Ptr region_colored_cloud_ptr_;
   std::vector<CloudRGB::Ptr> surface_clouds_;
   visualization_msgs::MarkerArray mesh_markers_;

--- a/godel_surface_detection/include/detection/surface_detection.h
+++ b/godel_surface_detection/include/detection/surface_detection.h
@@ -64,7 +64,7 @@ public:
   void get_full_cloud(CloudRGB& cloud);
   void get_full_cloud(sensor_msgs::PointCloud2 cloud_msg);
   void get_process_cloud(CloudRGB& cloud);
-  void get_process_cloud(sensor_msgs::PointCloud2 cloud_msg);
+  void get_process_cloud(sensor_msgs::PointCloud2& cloud_msg);
   void get_region_colored_cloud(CloudRGB& cloud);
   void get_region_colored_cloud(sensor_msgs::PointCloud2& cloud_msg);
 
@@ -83,7 +83,7 @@ private:
 
   // pcl members
   CloudRGB::Ptr full_cloud_ptr_;
-  CloudRGB::Ptr process_cloud_ptr;
+  CloudRGB::Ptr process_cloud_ptr_;
   CloudRGB::Ptr region_colored_cloud_ptr_;
   std::vector<CloudRGB::Ptr> surface_clouds_;
   visualization_msgs::MarkerArray mesh_markers_;

--- a/godel_surface_detection/include/services/surface_blending_service.h
+++ b/godel_surface_detection/include/services/surface_blending_service.h
@@ -93,7 +93,10 @@ public:
       PROCESS_PLANNING_ACTION_SERVER_NAME,
       boost::bind(&SurfaceBlendingService::processPlanningActionCallback, this, _1),
       false
-    ) {}
+    )
+  {
+   save_data_ = false;
+  }
 
   bool init();
   void run();
@@ -264,6 +267,8 @@ private:
 
   // parameters
   bool publish_region_point_cloud_;
+  bool save_data_;
+  std::string save_location_;
 
   // msgs
   sensor_msgs::PointCloud2 region_cloud_msg_;

--- a/godel_surface_detection/include/services/surface_blending_service.h
+++ b/godel_surface_detection/include/services/surface_blending_service.h
@@ -92,11 +92,9 @@ public:
       nh_,
       PROCESS_PLANNING_ACTION_SERVER_NAME,
       boost::bind(&SurfaceBlendingService::processPlanningActionCallback, this, _1),
-      false
-    )
-  {
-   save_data_ = false;
-  }
+      false),
+    save_data_(false)
+  {}
 
   bool init();
   void run();

--- a/godel_surface_detection/launch/godel_core.launch
+++ b/godel_surface_detection/launch/godel_core.launch
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <launch>
-  <!-- arguments -->
   <arg name="config_path"/>
-
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg if="$(arg debug)" name="launch_prefix" value="xterm -e gdb --args" />
+  <arg name="save_data" default="false" />
+  <arg name="save_location" default="$(env HOME)/.ros/" />
 
-    <!-- surface detection service -->
   <node name="surface_blending_service" pkg="godel_surface_detection" type="surface_blending_service" output="screen"
         required="true" launch-prefix="$(arg launch_prefix)">
     <rosparam command="load" file="$(arg config_path)/robot_scan.yaml"/>
@@ -16,10 +15,9 @@
     <rosparam command="load" file="$(arg config_path)/scan_plan.yaml"/>
     <rosparam command="load" file="$(arg config_path)/plugins.yaml"/>
     <param name="publish_region_point_cloud" value="True"/>
+    <param name="save_data" value="$(arg save_data)" />
+    <param name="save_location" value="$(arg save_location)"/>
   </node>
-
-  <!-- Blending Tool Path Generation Nodes -->
-  <!-- Used in the default blend path generation plugin -->
   <node name="process_path_generator_node" pkg="godel_process_path_generation" type="process_path_generator_node"/>
   <node name="polygon_offset_node" pkg="godel_polygon_offset" type="godel_polygon_offset_node"/>
 </launch>

--- a/godel_surface_detection/src/coordination/data_coordinator.cpp
+++ b/godel_surface_detection/src/coordination/data_coordinator.cpp
@@ -393,8 +393,9 @@ namespace data
       auto thd = std::thread(&DataCoordinator::saveRecord, this, path);
       thd.detach();
     }
-    catch (const std::exception& e){
-      ROS_WARN_STREAM("Data Save Error.");
+    catch (const std::exception& e)
+    {
+      ROS_WARN_STREAM("Could not create save thread");
     }
   }
 
@@ -419,31 +420,40 @@ namespace data
         return;
       }
 
-      // write input_cloud_ to pcd files
-      for(auto& rec : records_)
+      try
       {
-        std::stringstream save_loc;
-        save_loc << path.string() << session_id.str() << "_" << "input_cloud_"
-                 <<  rec.id_ << ".pcd";
-        int results;
-        results = pcl::io::savePCDFile(save_loc.str(),
-                                                   rec.input_cloud_);
-        if(results!=0)
-          ROS_WARN_STREAM("input_cloud_ files not saved.");
+        // write input_cloud_ to pcd files
+        for(auto& rec : records_)
+        {
+          if(!rec.input_cloud_.empty())
+          {
+            std::stringstream save_loc;
+            save_loc << path.string() << session_id.str() << "_" << "input_cloud_"
+                     <<  rec.id_ << ".pcd";
+            int results;
+            results = pcl::io::savePCDFile(save_loc.str(),
+                                                       rec.input_cloud_);
+            if(results!=0)
+              ROS_WARN_STREAM("input_cloud_ files not saved.");
+          }
+          if(!process_cloud_.empty())
+          {
+            //write process_cloud_ to pcd file
+            std::stringstream save_loc;
+            save_loc << path.string() << session_id.str() << "_"
+                     << "process_cloud.pcd";
+            int results;
+            results = pcl::io::savePCDFile(save_loc.str(), process_cloud_);
+            if(results!=0){
+              ROS_WARN_STREAM("process_cloud_ files not saved.");
+            }
+          }
+        }
       }
-
-    //write process_cloud_ to pcd file
-    std::stringstream save_loc;
-    save_loc << path.string() << session_id.str() << "_"
-             << "process_cloud.pcd";
-    int results;
-    results = pcl::io::savePCDFile(save_loc.str(), process_cloud_);
-    if(results!=0){
-      ROS_WARN_STREAM("process_cloud_ files not saved.");
-    }
-
+      catch (const std::exception& e){
+        ROS_WARN_STREAM("Data Save Error.");
+      }
     ROS_INFO_STREAM("Data Saved.");
-
   }
 } /* end namespace data */
 } /* end namespace godel_surface_detection */

--- a/godel_surface_detection/src/coordination/data_coordinator.cpp
+++ b/godel_surface_detection/src/coordination/data_coordinator.cpp
@@ -420,14 +420,14 @@ namespace data
       }
 
       // write input_cloud_ to pcd files
-      for(int i=0; i<records_.size(); ++i)
+      for(auto& rec : records_)
       {
         std::stringstream save_loc;
         save_loc << path.string() << session_id.str() << "_" << "input_cloud_"
-                 <<  records_[i].id_ << ".pcd";
+                 <<  rec.id_ << ".pcd";
         int results;
         results = pcl::io::savePCDFile(save_loc.str(),
-                                                   records_[i].input_cloud_);
+                                                   rec.input_cloud_);
         if(results!=0)
           ROS_WARN_STREAM("input_cloud_ files not saved.");
       }

--- a/godel_surface_detection/src/detection/surface_detection.cpp
+++ b/godel_surface_detection/src/detection/surface_detection.cpp
@@ -139,7 +139,7 @@ namespace godel_surface_detection
   {
     SurfaceDetection::SurfaceDetection()
       : full_cloud_ptr_(new CloudRGB())
-      , process_cloud_ptr(new CloudRGB())
+      , process_cloud_ptr_(new CloudRGB())
       , acquired_clouds_counter_(0)
       , random_engine_(0) // This is using a fixed seed for down-sampling at the moment
     {
@@ -173,7 +173,7 @@ namespace godel_surface_detection
     bool SurfaceDetection::init()
     {
       full_cloud_ptr_->header.frame_id = params_.frame_id;
-      process_cloud_ptr->header.frame_id = params_.frame_id;
+      process_cloud_ptr_->header.frame_id = params_.frame_id;
       acquired_clouds_counter_ = 0;
       return true;
     }
@@ -182,7 +182,7 @@ namespace godel_surface_detection
     {
       acquired_clouds_counter_ = 0;
       full_cloud_ptr_->clear();
-      process_cloud_ptr->clear();
+      process_cloud_ptr_->clear();
       surface_clouds_.clear();
       mesh_markers_.markers.clear();
       meshes_.clear();
@@ -307,12 +307,12 @@ namespace godel_surface_detection
 
     void SurfaceDetection::get_process_cloud(CloudRGB& cloud)
     {
-      pcl::copyPointCloud(*process_cloud_ptr, cloud);
+      pcl::copyPointCloud(*process_cloud_ptr_, cloud);
     }
 
-    void SurfaceDetection::get_process_cloud(sensor_msgs::PointCloud2 cloud_msg)
+    void SurfaceDetection::get_process_cloud(sensor_msgs::PointCloud2 &cloud_msg)
     {
-      pcl::toROSMsg(*process_cloud_ptr, cloud_msg);
+      pcl::toROSMsg(*process_cloud_ptr_, cloud_msg);
     }
 
     void SurfaceDetection::get_region_colored_cloud(CloudRGB& cloud)
@@ -355,10 +355,10 @@ namespace godel_surface_detection
       vox.setLeafSize (INPUT_CLOUD_VOXEL_FILTER_SIZE,
                        INPUT_CLOUD_VOXEL_FILTER_SIZE,
                        INPUT_CLOUD_VOXEL_FILTER_SIZE);
-      vox.filter(*process_cloud_ptr);
+      vox.filter(*process_cloud_ptr_);
 
       // Segment the part into surface clusters using a "region growing" scheme
-      SurfaceSegmentation SS(process_cloud_ptr);
+      SurfaceSegmentation SS(process_cloud_ptr_);
       region_colored_cloud_ptr_ = CloudRGB::Ptr(new CloudRGB());
       {
         SWRI_PROFILE("segment-clouds");

--- a/godel_surface_detection/src/detection/surface_detection.cpp
+++ b/godel_surface_detection/src/detection/surface_detection.cpp
@@ -15,7 +15,6 @@
 */
 
 #include <detection/surface_detection.h>
-#include <coordination/data_coordinator.h>
 #include <godel_param_helpers/godel_param_helpers.h>
 #include <meshing_plugins_base/meshing_base.h>
 #include <pcl_conversions/pcl_conversions.h>
@@ -140,6 +139,7 @@ namespace godel_surface_detection
   {
     SurfaceDetection::SurfaceDetection()
       : full_cloud_ptr_(new CloudRGB())
+      , process_cloud_ptr(new CloudRGB())
       , acquired_clouds_counter_(0)
       , random_engine_(0) // This is using a fixed seed for down-sampling at the moment
     {
@@ -173,6 +173,7 @@ namespace godel_surface_detection
     bool SurfaceDetection::init()
     {
       full_cloud_ptr_->header.frame_id = params_.frame_id;
+      process_cloud_ptr->header.frame_id = params_.frame_id;
       acquired_clouds_counter_ = 0;
       return true;
     }
@@ -181,6 +182,7 @@ namespace godel_surface_detection
     {
       acquired_clouds_counter_ = 0;
       full_cloud_ptr_->clear();
+      process_cloud_ptr->clear();
       surface_clouds_.clear();
       mesh_markers_.markers.clear();
       meshes_.clear();
@@ -298,12 +300,20 @@ namespace godel_surface_detection
       pcl::copyPointCloud(*full_cloud_ptr_, cloud);
     }
 
-
     void SurfaceDetection::get_full_cloud(sensor_msgs::PointCloud2 cloud_msg)
     {
       pcl::toROSMsg(*full_cloud_ptr_, cloud_msg);
     }
 
+    void SurfaceDetection::get_process_cloud(CloudRGB& cloud)
+    {
+      pcl::copyPointCloud(*process_cloud_ptr, cloud);
+    }
+
+    void SurfaceDetection::get_process_cloud(sensor_msgs::PointCloud2 cloud_msg)
+    {
+      pcl::toROSMsg(*process_cloud_ptr, cloud_msg);
+    }
 
     void SurfaceDetection::get_region_colored_cloud(CloudRGB& cloud)
     {
@@ -340,9 +350,6 @@ namespace godel_surface_detection
         return false;
 
       // Create Processing Cloud
-      pcl::PointCloud<pcl::PointXYZRGB>::Ptr process_cloud_ptr (
-            new pcl::PointCloud<pcl::PointXYZRGB>());
-      process_cloud_ptr->header = full_cloud_ptr_->header;
       pcl::VoxelGrid<pcl::PointXYZRGB> vox;
       vox.setInputCloud (full_cloud_ptr_);
       vox.setLeafSize (INPUT_CLOUD_VOXEL_FILTER_SIZE,


### PR DESCRIPTION
The user must issue the save_data argument, for example:
```
roslaunch godel_irb2400_support irb2400_blending.launch real_pcd:=true pcd_location:=/home/aderic/godel_point_cloud_data/scene1.pcd pcd_frame:=tool0 save_data:=true
```
the default directory is the `~/.ros` directory, which can be overran with the save_location argument.

This PR accomplished the following:
- The data coordinator now collects the processed point cloud
- The save data function is threaded and detached so the program will continue while the data is saved.
- The entire SurfaceDetectionRecord is not saved, this is a TODO
- We do not current have a session ID, this is a TODO