### PR TITLE
Feature/start stop ensenso

### DIFF
--- a/godel_msgs/CMakeLists.txt
+++ b/godel_msgs/CMakeLists.txt
@@ -47,6 +47,7 @@ add_service_files(
   BlendingPlan.srv
   BlendProcessExecution.srv
   BlendProcessPlanning.srv
+  EnsensoCommand.srv
   GetAvailableMotionPlans.srv
   KeyenceProcessExecution.srv
   KeyenceProcessPlanning.srv

--- a/godel_msgs/action/BlendProcessExecution.action
+++ b/godel_msgs/action/BlendProcessExecution.action
@@ -1,0 +1,19 @@
+# Goal
+trajectory_msgs/JointTrajectory trajectory_approach
+trajectory_msgs/JointTrajectory trajectory_process
+trajectory_msgs/JointTrajectory trajectory_depart
+
+bool wait_for_execution
+
+bool simulate
+
+godel_msgs/BlendingPlanParameters params
+
+---
+
+# Result
+bool success
+
+---
+
+# Feedback is empty (completion of task is our main concern)

--- a/godel_msgs/srv/EnsensoCommand.srv
+++ b/godel_msgs/srv/EnsensoCommand.srv
@@ -1,0 +1,8 @@
+# EnsensoCommand
+# Called to manage the ensenso_publisher node (e.g. to start or stop the ensenso)
+int32 STOP=0
+int32 START=1
+
+int32 action
+---
+bool result

--- a/godel_process_execution/CMakeLists.txt
+++ b/godel_process_execution/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(godel_process_execution)
+add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
   abb_file_suite
@@ -7,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   industrial_robot_simulator_service
   trajectory_msgs
   keyence_experimental
+  swri_profiler
 )
 
 catkin_package(
@@ -18,6 +20,7 @@ catkin_package(
     industrial_robot_simulator_service
     trajectory_msgs
     keyence_experimental
+    swri_profiler
 )
 
 include_directories(

--- a/godel_process_execution/CMakeLists.txt
+++ b/godel_process_execution/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
   industrial_robot_simulator_service
   trajectory_msgs
   keyence_experimental
-  swri_profiler
 )
 
 catkin_package(
@@ -20,7 +19,6 @@ catkin_package(
     industrial_robot_simulator_service
     trajectory_msgs
     keyence_experimental
-    swri_profiler
 )
 
 include_directories(

--- a/godel_process_execution/package.xml
+++ b/godel_process_execution/package.xml
@@ -18,5 +18,6 @@
   <depend>industrial_robot_simulator_service</depend>
   <depend>trajectory_msgs</depend>
   <depend>keyence_experimental</depend>
+  <depend>swri_profiler</depend>
 
 </package>

--- a/godel_process_execution/src/abb_blend_process_service.cpp
+++ b/godel_process_execution/src/abb_blend_process_service.cpp
@@ -207,17 +207,19 @@ bool godel_process_execution::AbbBlendProcessService::executeProcess(
     return false;
   }
 
-  if (!req.wait_for_execution)
+  if (req.wait_for_execution)
+  {
+    // If we must wait for execution, then block and listen until robot returns to initial point or
+    // times out
+    return waitForExecution(req.trajectory_approach.points.front().positions,
+                            aggregate_traj.points.back().time_from_start, // wait for
+                            aggregate_traj.points.back().time_from_start +
+                                ros::Duration(DEFAULT_TRAJECTORY_BUFFER_TIME)); // timeout
+  }
+  else
   {
     return true;
   }
-
-  // If we must wait for execution, then block and listen until robot returns to initial point or
-  // times out
-  return waitForExecution(req.trajectory_approach.points.front().positions,
-                          aggregate_traj.points.back().time_from_start, // wait for
-                          aggregate_traj.points.back().time_from_start +
-                              ros::Duration(DEFAULT_TRAJECTORY_BUFFER_TIME)); // timeout
 }
 
 bool godel_process_execution::AbbBlendProcessService::simulateProcess(

--- a/godel_surface_detection/CMakeLists.txt
+++ b/godel_surface_detection/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   godel_param_helpers
   godel_msgs
   godel_plugins
+  godel_utils
   meshing_plugins_base
   path_planning_plugins_base
   swri_profiler
@@ -49,6 +50,7 @@ catkin_package(
     godel_param_helpers
     godel_msgs
     godel_plugins
+    godel_utils
     meshing_plugins_base
     path_planning_plugins_base
 )
@@ -72,7 +74,8 @@ add_library(${PROJECT_NAME}
   src/scan/robot_scan.cpp
   src/interactive/interactive_surface_server.cpp
   src/services/trajectory_library.cpp
-  src/utils/mesh_conversions.cpp)
+  src/utils/mesh_conversions.cpp
+)
 
 target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_FLAGS})
 

--- a/godel_surface_detection/package.xml
+++ b/godel_surface_detection/package.xml
@@ -28,6 +28,7 @@
   <depend>godel_process_path_generation</depend>
   <depend>godel_param_helpers</depend>
   <depend>godel_plugins</depend>
+  <depend>godel_utils</depend>
   <depend>meshing_plugins_base</depend>
   <depend>path_planning_plugins_base</depend>
   <depend>swri_profiler</depend>

--- a/godel_surface_detection/src/services/blending_service_path_generation.cpp
+++ b/godel_surface_detection/src/services/blending_service_path_generation.cpp
@@ -241,7 +241,7 @@ SurfaceBlendingService::generateProcessPath(const int& id,
                                             godel_surface_detection::detection::CloudRGB::Ptr surface,
                                             ProcessPathResult& result)
 {
-  SWRI_PROFILE("tool-planning")
+  SWRI_PROFILE("tool-planning");
   std::vector<geometry_msgs::PoseArray> blend_result, edge_result, scan_result;
 
   // Step 1: Generate Blending Paths

--- a/godel_surface_detection/src/services/surface_blending_service.cpp
+++ b/godel_surface_detection/src/services/surface_blending_service.cpp
@@ -13,6 +13,9 @@
 #include "godel_msgs/KeyenceProcessPlanning.h"
 #include "godel_msgs/PathPlanning.h"
 
+#include <godel_param_helpers/godel_param_helpers.h>
+#include <godel_utils/ensenso_guard.h>
+
 // topics and services
 const static std::string SAVE_DATA_BOOL_PARAM = "save_data";
 const static std::string SAVE_LOCATION_PARAM = "save_location";
@@ -33,6 +36,8 @@ const static std::string BLEND_PROCESS_EXECUTION_SERVICE = "blend_process_execut
 const static std::string SCAN_PROCESS_EXECUTION_SERVICE = "scan_process_execution";
 const static std::string BLEND_PROCESS_PLANNING_SERVICE = "blend_process_planning";
 const static std::string SCAN_PROCESS_PLANNING_SERVICE = "keyence_process_planning";
+
+const static std::string ENSENSO_SERVICE = "ensenso_manager";
 
 const static std::string TOOL_PATH_PREVIEW_TOPIC = "tool_path_preview";
 const static std::string EDGE_VISUALIZATION_TOPIC = "edge_visualization";
@@ -308,6 +313,7 @@ bool SurfaceBlendingService::run_robot_scan(visualization_msgs::MarkerArray& sur
   int scans_completed = robot_scan_.scan(false);
   if (scans_completed > 0)
   {
+    ensenso::EnsensoGuard guard;
     succeeded = find_surfaces(surfaces);
   }
   else
@@ -549,26 +555,31 @@ void SurfaceBlendingService::processPlanningActionCallback(const godel_msgs::Pro
 {
   switch (goal->action)
   {
-  case godel_msgs::ProcessPlanningGoal::GENERATE_MOTION_PLAN_AND_PREVIEW:
-    process_planning_feedback_.last_completed = "Recieved request to generate motion plan";
-    process_planning_server_.publishFeedback(process_planning_feedback_);
-    trajectory_library_ = generateMotionLibrary(goal->params);
-    process_planning_feedback_.last_completed = "Finished planning. Visualizing...";
-    process_planning_server_.publishFeedback(process_planning_feedback_);
-    visualizePaths();
-    process_planning_result_.succeeded = true;
-    process_planning_server_.setSucceeded(process_planning_result_);
-    break;
+    case godel_msgs::ProcessPlanningGoal::GENERATE_MOTION_PLAN_AND_PREVIEW:
+    {
+      ensenso::EnsensoGuard guard; // turns off ensenso for planning and turns it on when this goes out of scope
+      process_planning_feedback_.last_completed = "Recieved request to generate motion plan";
+      process_planning_server_.publishFeedback(process_planning_feedback_);
+      trajectory_library_ = generateMotionLibrary(goal->params);
+      process_planning_feedback_.last_completed = "Finished planning. Visualizing...";
+      process_planning_server_.publishFeedback(process_planning_feedback_);
+      visualizePaths();
+      process_planning_result_.succeeded = true;
+      process_planning_server_.setSucceeded(process_planning_result_);
+      break;
+    }
+    case godel_msgs::ProcessPlanningGoal::PREVIEW_TOOL_PATH:
+    {
+      process_planning_feedback_.last_completed = "Recieved request to preview tool path";
+      process_planning_server_.publishFeedback(process_planning_feedback_);
+      break;
+    }
 
-  case godel_msgs::ProcessPlanningGoal::PREVIEW_TOOL_PATH:
-    process_planning_feedback_.last_completed = "Recieved request to preview tool path";
-    process_planning_server_.publishFeedback(process_planning_feedback_);
-    break;
-
-  default:
-
-    ROS_ERROR_STREAM("Unknown action code '" << goal->action << "' request");
-    break;
+    default:
+    {
+      ROS_ERROR_STREAM("Unknown action code '" << goal->action << "' request");
+      break;
+    }
   }
 
   process_planning_result_.succeeded = false;
@@ -671,6 +682,8 @@ bool SurfaceBlendingService::surface_blend_parameters_server_callback(
 bool SurfaceBlendingService::selectMotionPlanCallback(godel_msgs::SelectMotionPlan::Request& req,
                                                       godel_msgs::SelectMotionPlan::Response& res)
 {
+  ensenso::EnsensoGuard guard;  // Turn off camera while we execute
+
   // Check to ensure the plan exists
   if (trajectory_library_.get().find(req.name) == trajectory_library_.get().end())
   {

--- a/godel_surface_detection/src/services/surface_blending_service.cpp
+++ b/godel_surface_detection/src/services/surface_blending_service.cpp
@@ -37,8 +37,6 @@ const static std::string SCAN_PROCESS_EXECUTION_SERVICE = "scan_process_executio
 const static std::string BLEND_PROCESS_PLANNING_SERVICE = "blend_process_planning";
 const static std::string SCAN_PROCESS_PLANNING_SERVICE = "keyence_process_planning";
 
-const static std::string ENSENSO_SERVICE = "ensenso_manager";
-
 const static std::string TOOL_PATH_PREVIEW_TOPIC = "tool_path_preview";
 const static std::string EDGE_VISUALIZATION_TOPIC = "edge_visualization";
 const static std::string BLEND_VISUALIZATION_TOPIC = "blend_visualization";

--- a/godel_utils/CMakeLists.txt
+++ b/godel_utils/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(godel_utils)
+
+## Add support for C++11, supported in ROS Kinetic and newer
+add_definitions(-std=c++11)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED
+    godel_msgs)
+
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+
+catkin_package(
+    INCLUDE_DIRS
+      include
+    LIBRARIES
+      ${PROJECT_NAME}
+    CATKIN_DEPENDS
+      roscpp
+      godel_msgs
+)
+
+###########
+## Build ##
+###########
+
+include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+add_library(${PROJECT_NAME}
+   src/ensenso_guard.cpp
+)
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)

--- a/godel_utils/include/godel_utils/ensenso_guard.h
+++ b/godel_utils/include/godel_utils/ensenso_guard.h
@@ -1,0 +1,21 @@
+#ifndef ENSENSO_GUARD_H
+#define ENSESNO_GUARD_H
+
+#include <ros/node_handle.h>
+#include <ros/service_client.h>
+
+namespace ensenso
+{
+class EnsensoGuard
+{
+private:
+  ros::NodeHandle nh_;
+  ros::ServiceClient client_;
+public:
+  EnsensoGuard();
+  ~EnsensoGuard();
+};
+
+}
+
+#endif // ENSENSO_GUARD_H

--- a/godel_utils/include/godel_utils/ensenso_guard.h
+++ b/godel_utils/include/godel_utils/ensenso_guard.h
@@ -6,6 +6,8 @@
 
 namespace ensenso
 {
+enum Command {STOP=0, START=1};
+
 class EnsensoGuard
 {
 private:
@@ -14,6 +16,7 @@ private:
 public:
   EnsensoGuard();
   ~EnsensoGuard();
+  void issueCommand(Command command);
 };
 
 }

--- a/godel_utils/package.xml
+++ b/godel_utils/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>godel_utils</name>
+  <version>0.0.1</version>
+  <description>A utility package for common Godel resources</description>
+
+  <maintainer email="ros-industrial@todo.todo">ros-industrial</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <author email="awood@swri.org">Aaron Wood</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>roscpp</depend>
+  <depend>godel_msgs</depend>
+  <export></export>
+
+</package>

--- a/godel_utils/package.xml
+++ b/godel_utils/package.xml
@@ -10,7 +10,7 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>Apache 2.0</license>
 
 
   <author email="awood@swri.org">Aaron Wood</author>

--- a/godel_utils/src/ensenso_guard.cpp
+++ b/godel_utils/src/ensenso_guard.cpp
@@ -7,30 +7,39 @@ const static std::string SERVICE_NAME = "ensenso_manager";
 
 EnsensoGuard::EnsensoGuard() : client_(nh_.serviceClient<godel_msgs::EnsensoCommand>(SERVICE_NAME))
 {
-  godel_msgs::EnsensoCommand msg;
-  msg.request.action = godel_msgs::EnsensoCommandRequest::STOP;
-  try
-  {
-    client_.call(msg);
-  }
-  catch (const std::exception e)
-  {
-    ROS_ERROR_STREAM("Exception while attempting to stop ensenso: " << e.what());
-  }
+  issueCommand(Command::STOP);
 }
 
 EnsensoGuard::~EnsensoGuard()
 {
+  issueCommand(Command::START);
+}
+
+void EnsensoGuard::issueCommand(Command command)
+{
   godel_msgs::EnsensoCommand msg;
-  msg.request.action = godel_msgs::EnsensoCommandRequest::START;
-  try
-  {
-    client_.call(msg);
-  }
-  catch (const std::exception e)
-  {
-    ROS_ERROR_STREAM("Exception while attempting to restart ensenso: " << e.what());
-  }
+    msg.request.action = command;
+    try
+    {
+      client_.call(msg);
+    }
+    catch (const std::exception& e)
+    {
+      std::string command_type;
+      switch(command)
+      {
+        case Command::STOP :
+        {
+          command_type = "stop";
+        }
+        case Command::START :
+        {
+          command_type = "start";
+        }
+      }
+
+      ROS_ERROR_STREAM("Exception while attempting to " << command_type <<  " ensenso: " << e.what());
+    }
 }
 
 }

--- a/godel_utils/src/ensenso_guard.cpp
+++ b/godel_utils/src/ensenso_guard.cpp
@@ -1,0 +1,36 @@
+#include <godel_msgs/EnsensoCommand.h>
+#include <godel_utils/ensenso_guard.h>
+
+namespace ensenso
+{
+const static std::string SERVICE_NAME = "ensenso_manager";
+
+EnsensoGuard::EnsensoGuard() : client_(nh_.serviceClient<godel_msgs::EnsensoCommand>(SERVICE_NAME))
+{
+  godel_msgs::EnsensoCommand msg;
+  msg.request.action = godel_msgs::EnsensoCommandRequest::STOP;
+  try
+  {
+    client_.call(msg);
+  }
+  catch (const std::exception e)
+  {
+    ROS_ERROR_STREAM("Exception while attempting to stop ensenso: " << e.what());
+  }
+}
+
+EnsensoGuard::~EnsensoGuard()
+{
+  godel_msgs::EnsensoCommand msg;
+  msg.request.action = godel_msgs::EnsensoCommandRequest::START;
+  try
+  {
+    client_.call(msg);
+  }
+  catch (const std::exception e)
+  {
+    ROS_ERROR_STREAM("Exception while attempting to restart ensenso: " << e.what());
+  }
+}
+
+}


### PR DESCRIPTION
Adds a new package called "godel_utils" which is meant to house lightweight utility classes common to several nodes. Hopefully, this will help avoid large build dependencies.

The first class for this package is EnsensoGuard which stops the Ensenso on construction and re-starts it when it goes out of scope.

In support of starting and stopping the Ensenso, this PR also adds a service call (EnsensoCommand) which currently can only start/stop the camera but may eventually accommodate other requests (e.g. take a single picture, change calibration parameters, etc).