### PR TITLE
Parameter Tweaks

### DIFF
--- a/godel_robots/abb/godel_irb1200/godel_irb1200_moveit_config/config/ompl_planning.yaml
+++ b/godel_robots/abb/godel_irb1200/godel_irb1200_moveit_config/config/ompl_planning.yaml
@@ -30,7 +30,7 @@ planner_configs:
     goal_bias: 0.05  # When close to goal select goal, with this probability? default: 0.05
   RRTConnectkConfigDefault:
     type: geometric::RRTConnect
-    range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
+    range: 0.005  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()
   RRTstarkConfigDefault:
     type: geometric::RRTstar
     range: 0.0  # Max motion added to tree. ==> maxDistance_ default: 0.0, if 0.0, set on setup()

--- a/godel_surface_detection/src/segmentation/surface_segmentation.cpp
+++ b/godel_surface_detection/src/segmentation/surface_segmentation.cpp
@@ -419,7 +419,8 @@ void SurfaceSegmentation::computeNormals()
   ne.setInputCloud (input_cloud_);
   pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB> ());
   ne.setSearchMethod (tree);
-  ne.setKSearch (100);
+  ne.setRadiusSearch(0.025);
+//  ne.setKSearch (100);
 
   // Estimate the normals
   ne.compute (*normals_);


### PR DESCRIPTION
Adjusts the RRT connect range param so that we have fewer flips with MoveIt.

Adjusts the radius search for blending points to smooth out surface normals a bit more.