### PR TITLE
Better Path Picking

### DIFF
--- a/godel.rosinstall
+++ b/godel.rosinstall
@@ -1,4 +1,3 @@
-- git: {local-name: descartes, uri: 'https://github.com/ros-industrial-consortium/descartes.git', version: kinetic-devel}
 - git: {local-name: godel_openvoronoi, uri: 'https://github.com/ros-industrial-consortium/godel_openvoronoi.git', version: hydro-devel}
 - git: {local-name: godel, uri: 'https://github.com/ros-industrial-consortium/godel.git', version: kinetic-devel}
 - git: {local-name: industrial_core, uri: 'https://github.com/ros-industrial/industrial_core.git', version: kinetic-devel}
@@ -8,4 +7,5 @@
 
 # Custom abb until Kinetic release happens
 - git: {local-name: abb, uri: 'https://github.com/Jmeyer1292/abb.git', version: kinetic-devel}
-
+# Custom descartes until we get changes merged in
+- git: {local-name: descartes, uri: 'https://github.com/Jmeyer1292/descartes.git', version: godel_refactor_omp}

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -87,14 +87,6 @@ bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlannin
   DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.traverse_spd, transition_params,
                                                  toDescartesBlendPt);
 
-  ROS_ERROR_STREAM("DESCARTES");
-  for (const descartes_core::TrajectoryPtPtr& pt : process_points)
-  {
-    Eigen::Affine3d pose;
-    double dt = pt->getTiming().upper;
-    pt->getNominalCartPose(std::vector<double>(), *blend_model_, pose);
-    ROS_ERROR_STREAM("POINT:\n" << pose.matrix() << "\nWITH DT = " << dt << "\n");
-  }
   if (generateMotionPlan(blend_model_, process_points, moveit_model_, blend_group_name_,
                          current_joints, res.plan))
   {

--- a/godel_process_planning/src/blend_process_planning.cpp
+++ b/godel_process_planning/src/blend_process_planning.cpp
@@ -86,6 +86,15 @@ bool ProcessPlanningManager::handleBlendPlanning(godel_msgs::BlendProcessPlannin
 
   DescartesTraj process_points = toDescartesTraj(req.path.segments, req.params.traverse_spd, transition_params,
                                                  toDescartesBlendPt);
+
+  ROS_ERROR_STREAM("DESCARTES");
+  for (const descartes_core::TrajectoryPtPtr& pt : process_points)
+  {
+    Eigen::Affine3d pose;
+    double dt = pt->getTiming().upper;
+    pt->getNominalCartPose(std::vector<double>(), *blend_model_, pose);
+    ROS_ERROR_STREAM("POINT:\n" << pose.matrix() << "\nWITH DT = " << dt << "\n");
+  }
   if (generateMotionPlan(blend_model_, process_points, moveit_model_, blend_group_name_,
                          current_joints, res.plan))
   {

--- a/godel_process_planning/src/common_utils.cpp
+++ b/godel_process_planning/src/common_utils.cpp
@@ -310,11 +310,11 @@ double godel_process_planning::freeSpaceCostFunction(const std::vector<double> &
                                                      const std::vector<double> &target)
 {
   const double FREE_SPACE_MAX_ANGLE_DELTA =
-      M_PI_2; // The maximum angle a joint during a freespace motion
+      M_PI; // The maximum angle a joint during a freespace motion
               // from the start to end position without that motion
               // being penalized. Avoids flips.
   const double FREE_SPACE_ANGLE_PENALTY =
-      5.0; // The factor by which a joint motion is multiplied if said
+      2.0; // The factor by which a joint motion is multiplied if said
            // motion is greater than the max.
 
   // The cost function here penalizes large single joint motions in an effort to

--- a/godel_process_planning/src/generate_motion_plan.cpp
+++ b/godel_process_planning/src/generate_motion_plan.cpp
@@ -1,10 +1,41 @@
 #include "generate_motion_plan.h"
+#include "trajectory_utils.h"
 #include "common_utils.h"
 #include <descartes_trajectory/axial_symmetric_pt.h>
 #include <descartes_trajectory/joint_trajectory_pt.h>
 
 #include <descartes_planner/ladder_graph_dag_search.h>
 #include <descartes_planner/dense_planner.h>
+
+const static bool validateTrajectory(const trajectory_msgs::JointTrajectory& pts,
+                                     const descartes_core::RobotModel& model,
+                                     const double min_segment_size)
+{
+  for (std::size_t i = 1; i < pts.points.size(); ++i)
+  {
+    const auto& pt_a = pts.points[i - 1].positions;
+    const auto& pt_b = pts.points[i].positions;
+
+    auto interpolate = godel_process_planning::interpolateJoint(pt_a, pt_b, min_segment_size);
+
+    // The thought here is that the graph building process already checks the waypoints in the
+    // trajectory for collisions. What we want to do is check between these waypoints when they
+    // move a lot. 'interpolateJoint()' returns a list of positions where the maximum joint motion
+    // between them is no more 'than min_segment_size' and its inclusive. So if there are only two
+    // solutions, then we just have the start & end which are already checked.
+    if (interpolate.size() > 2)
+    {
+      for (std::size_t j = 1; j < interpolate.size() - 1; ++j)
+      {
+        if (!model.isValid(interpolate[j]))
+        {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
 
 bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModelPtr model,
                                                 const std::vector<descartes_core::TrajectoryPtPtr> &traj,
@@ -14,58 +45,59 @@ bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModel
                                                 godel_msgs::ProcessPlan &plan)
 {
 
+  // Generate a graph of the process path joint solutions
   descartes_planner::PlanningGraph planning_graph (model);
   if (!planning_graph.insertGraph(traj)) // builds the graph out
   {
-    ROS_ERROR("Unable to build graph. One or more points do not have valid solutions.");
+    ROS_ERROR("%s: Failed to build graph. One or more points may have no valid IK solutions", __FUNCTION__);
     return false;
   }
+
+  // Using the valid starting configurations, let's compute an estimate
+  // of the cost to move to these configurations from our starting pose
   const auto& graph = planning_graph.graph();
   const auto dof = graph.dof();
 
-  // Compute a list of the starting points
   std::vector<std::vector<double>> process_start_poses;
-  const auto& data = graph.getRung(0).data;
-  const auto n_start_poses = data.size() / dof;
+  const auto& joint_data = graph.getRung(0).data; // This is a flat vector of doubles w/ all the solutions
+  const auto n_start_poses = joint_data.size() / dof;
 
-  for (std::size_t i = 0; i < n_start_poses; ++i)
+  for (std::size_t i = 0; i < n_start_poses; ++i) // This builds a list of starting poses
   {
-    std::vector<double> sol (&data[i * dof], &data[i*dof + dof]);
+    std::vector<double> sol (&joint_data[i * dof], &joint_data[i*dof + dof]);
     process_start_poses.push_back(sol);
   }
 
   std::vector<double> process_start_costs (process_start_poses.size());
-  for (std::size_t i = 0; i < process_start_costs.size(); ++i)
+  for (std::size_t i = 0; i < process_start_costs.size(); ++i) // This computes the list of configurations
   {
     process_start_costs[i] = freeSpaceCostFunction(start_state, process_start_poses[i]);
   }
 
-
-
+  // Now we perform the search using the starting costs from our estimation above
   descartes_planner::DAGSearch search (graph);
   double cost = search.run(process_start_costs);
   if (cost == std::numeric_limits<double>::max())
   {
-    ROS_ERROR("Unable to search graph completely");
+    ROS_ERROR("%s: Failed to search graph. All points have IK, but process constraints (e.g velocity) "
+              "prevent a solution", __FUNCTION__);
     return false;
   }
 
-
+  // Here we search the graph for the shortest path and build a descartes trajectory of it!
   auto path_idxs = search.shortestPath();
-  ROS_INFO("Computed path of length with cost %lf", path_idxs.size(), cost);
-
+  ROS_INFO("%s: Descartes computed path with cost %lf", __FUNCTION__, cost);
   DescartesTraj solution;
-
   for (size_t i = 0; i < path_idxs.size(); ++i)
   {
     const auto idx = path_idxs[i];
     const auto* data = graph.vertex(i, idx);
     const auto& tm = graph.getRung(i).timing;
-
     auto pt = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(std::vector<double>(data, data + dof), tm));
     solution.push_back(pt);
   }
 
+  // Now we plan our approach and depart to/from the path. We try to joint interpolate, and then we run from there
   try
   {
     trajectory_msgs::JointTrajectory approach =
@@ -80,6 +112,13 @@ bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModel
 
     // Break out the process path from the seed path and convert to ROS messages
     trajectory_msgs::JointTrajectory process = toROSTrajectory(solution, *model);
+
+    const static double SMALLEST_VALID_SEGMENT = 0.05;
+    if (!validateTrajectory(process, *model, SMALLEST_VALID_SEGMENT))
+    {
+      ROS_ERROR_STREAM("%s: Computed path contains joint configuration changes that would result in a collision.");
+      return false;
+    }
 
     // Fill in result trajectories
     plan.trajectory_process = process;
@@ -100,115 +139,4 @@ bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModel
     ROS_ERROR_STREAM("Exception caught when planning blending path: " << e.what());
     return false;
   }
-
-
-
-
-
-
-
-//  // Compute all of the joint poses at the start of the process path
-//  std::vector<std::vector<double> > start_joint_poses;
-//  traj.front()->getJointPoses(*model, start_joint_poses);
-
-//  if (start_joint_poses.empty())
-//  {
-//    ROS_WARN_STREAM("Blend Planning Service: Could not compute any inverse kinematic solutions for "
-//                    "the first point in the process path.");
-
-//    return false;
-//  }
-
-//  ROS_INFO_STREAM("Number of candidate poses: " << start_joint_poses.size());
-
-//  auto start_pose = godel_process_planning::pickBestStartPose(start_state, *model,
-//                                                              start_joint_poses,
-//                                                              freeSpaceCostFunction);
-
-//  DescartesTraj solved_path;
-//  // Calculate tool pose of robot starting config so that we can go back here on the
-//  // return move
-//  Eigen::Affine3d init_pose;
-//  model->getFK(start_state, init_pose);
-//  // Compute the nominal tool pose of the final process point
-//  Eigen::Affine3d process_stop_pose;
-//  traj.back()->getNominalCartPose(std::vector<double>(), *model,
-//                                  process_stop_pose);
-
-//  // Joint interpolate from the initial robot position to 'best' starting configuration of process
-//  // path
-//  DescartesTraj to_process = createJointPath(start_state, start_pose);
-//  to_process.front() =
-//      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
-
-//  // To get a rough estimate of process path cost, add a cartesian move from the final process point
-//  // to the starting position again.
-//  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
-//  from_process.back() =
-//      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
-
-//  // Affix the approach and depart paths calculated above with user process path
-//  DescartesTraj seed_path;
-//  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
-//  seed_path.insert(seed_path.end(), traj.begin(), traj.end());
-//  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
-
-//  // Attempt to solve the initial path (minimize joint motion over entire plan)
-//  if (!descartesSolve(seed_path, model, solved_path))
-//  {
-//    return false;
-//  }
-
-//  // Go back over and recalculate the approach and depart segments to:
-//  //  1. Use a joint interpolation from start to stop if collision free
-//  //  2. Use MoveIt (RRT-Connect) if the above fails
-//  // This is the only portion of the trajectory that is collision checked. Note this
-//  // method also converts the Descartes points into ROS trajectories.
-//  try
-//  {
-//    trajectory_msgs::JointTrajectory approach =
-//        planFreeMove(*model, move_group_name, moveit_model,
-//                     extractJoints(*model, *solved_path[0]),
-//                     extractJoints(*model, *solved_path[to_process.size()]));
-
-//    trajectory_msgs::JointTrajectory depart = planFreeMove(
-//        *model, move_group_name, moveit_model,
-//        extractJoints(*model, *solved_path[to_process.size() + traj.size() - 1]),
-//        extractJoints(*model, *solved_path[seed_path.size() - 1]));
-
-//    // Break out the process path from the seed path and convert to ROS messages
-//    DescartesTraj process_part(solved_path.begin() + to_process.size(),
-//                               solved_path.end() - from_process.size());
-//    trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *model);
-
-//    for (std::size_t i = 0; i < process.points.size(); ++i)
-//    {
-//      const auto& pt = process.points[i];
-//      if (!model->isValid(pt.positions))
-//      {
-//        ROS_WARN_STREAM("Position in blending path (" << i << ") invalid: Joint limit or collision detected\n");
-//        return false;
-//      }
-//    }
-
-
-//    // Fill in result trajectories
-//    plan.trajectory_process = process;
-//    plan.trajectory_approach = approach;
-//    plan.trajectory_depart = depart;
-
-//    // Fill in result header information
-//    const std::vector<std::string>& joint_names =
-//        moveit_model->getJointModelGroup(move_group_name)->getActiveJointModelNames();
-
-//    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_approach);
-//    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_depart);
-//    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_process);
-//    return true;
-//  }
-//  catch (const std::runtime_error& e)
-//  {
-//    ROS_ERROR_STREAM("Exception caught when planning blending path: " << e.what());
-//    return false;
-//  }
 }

--- a/godel_process_planning/src/generate_motion_plan.cpp
+++ b/godel_process_planning/src/generate_motion_plan.cpp
@@ -15,8 +15,11 @@ bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModel
 {
 
   descartes_planner::PlanningGraph planning_graph (model);
-  planning_graph.insertGraph(traj); // builds the graph out
-
+  if (!planning_graph.insertGraph(traj)) // builds the graph out
+  {
+    ROS_ERROR("Unable to build graph. One or more points do not have valid solutions.");
+    return false;
+  }
   const auto& graph = planning_graph.graph();
   const auto dof = graph.dof();
 

--- a/godel_process_planning/src/generate_motion_plan.cpp
+++ b/godel_process_planning/src/generate_motion_plan.cpp
@@ -3,6 +3,9 @@
 #include <descartes_trajectory/axial_symmetric_pt.h>
 #include <descartes_trajectory/joint_trajectory_pt.h>
 
+#include <descartes_planner/ladder_graph_dag_search.h>
+#include <descartes_planner/dense_planner.h>
+
 bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModelPtr model,
                                                 const std::vector<descartes_core::TrajectoryPtPtr> &traj,
                                                 moveit::core::RobotModelConstPtr moveit_model,
@@ -10,90 +13,70 @@ bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModel
                                                 const std::vector<double> &start_state,
                                                 godel_msgs::ProcessPlan &plan)
 {
-  // Compute all of the joint poses at the start of the process path
-  std::vector<std::vector<double> > start_joint_poses;
-  traj.front()->getJointPoses(*model, start_joint_poses);
 
-  if (start_joint_poses.empty())
+  descartes_planner::PlanningGraph planning_graph (model);
+  planning_graph.insertGraph(traj); // builds the graph out
+
+  const auto& graph = planning_graph.graph();
+  const auto dof = graph.dof();
+
+  // Compute a list of the starting points
+  std::vector<std::vector<double>> process_start_poses;
+  const auto& data = graph.getRung(0).data;
+  const auto n_start_poses = data.size() / dof;
+
+  for (std::size_t i = 0; i < n_start_poses; ++i)
   {
-    ROS_WARN_STREAM("Blend Planning Service: Could not compute any inverse kinematic solutions for "
-                    "the first point in the process path.");
+    std::vector<double> sol (&data[i * dof], &data[i*dof + dof]);
+    process_start_poses.push_back(sol);
+  }
 
+  std::vector<double> process_start_costs (process_start_poses.size());
+  for (std::size_t i = 0; i < process_start_costs.size(); ++i)
+  {
+    process_start_costs[i] = freeSpaceCostFunction(start_state, process_start_poses[i]);
+  }
+
+
+
+  descartes_planner::DAGSearch search (graph);
+  double cost = search.run(process_start_costs);
+  if (cost == std::numeric_limits<double>::max())
+  {
+    ROS_ERROR("Unable to search graph completely");
     return false;
   }
 
-  ROS_INFO_STREAM("Number of candidate poses: " << start_joint_poses.size());
 
-  auto start_pose = godel_process_planning::pickBestStartPose(start_state, *model,
-                                                              start_joint_poses,
-                                                              freeSpaceCostFunction);
+  auto path_idxs = search.shortestPath();
+  ROS_INFO("Computed path of length with cost %lf", path_idxs.size(), cost);
 
-  DescartesTraj solved_path;
-  // Calculate tool pose of robot starting config so that we can go back here on the
-  // return move
-  Eigen::Affine3d init_pose;
-  model->getFK(start_state, init_pose);
-  // Compute the nominal tool pose of the final process point
-  Eigen::Affine3d process_stop_pose;
-  traj.back()->getNominalCartPose(std::vector<double>(), *model,
-                                  process_stop_pose);
+  DescartesTraj solution;
 
-  // Joint interpolate from the initial robot position to 'best' starting configuration of process
-  // path
-  DescartesTraj to_process = createJointPath(start_state, start_pose);
-  to_process.front() =
-      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
-
-  // To get a rough estimate of process path cost, add a cartesian move from the final process point
-  // to the starting position again.
-  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
-  from_process.back() =
-      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
-
-  // Affix the approach and depart paths calculated above with user process path
-  DescartesTraj seed_path;
-  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
-  seed_path.insert(seed_path.end(), traj.begin(), traj.end());
-  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
-
-  // Attempt to solve the initial path (minimize joint motion over entire plan)
-  if (!descartesSolve(seed_path, model, solved_path))
+  for (size_t i = 0; i < path_idxs.size(); ++i)
   {
-    return false;
+    const auto idx = path_idxs[i];
+    const auto* data = graph.vertex(i, idx);
+    const auto& tm = graph.getRung(i).timing;
+
+    auto pt = descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(std::vector<double>(data, data + dof), tm));
+    solution.push_back(pt);
   }
 
-  // Go back over and recalculate the approach and depart segments to:
-  //  1. Use a joint interpolation from start to stop if collision free
-  //  2. Use MoveIt (RRT-Connect) if the above fails
-  // This is the only portion of the trajectory that is collision checked. Note this
-  // method also converts the Descartes points into ROS trajectories.
   try
   {
     trajectory_msgs::JointTrajectory approach =
         planFreeMove(*model, move_group_name, moveit_model,
-                     extractJoints(*model, *solved_path[0]),
-                     extractJoints(*model, *solved_path[to_process.size()]));
+                     start_state,
+                     extractJoints(*model, *solution.front()));
 
     trajectory_msgs::JointTrajectory depart = planFreeMove(
         *model, move_group_name, moveit_model,
-        extractJoints(*model, *solved_path[to_process.size() + traj.size() - 1]),
-        extractJoints(*model, *solved_path[seed_path.size() - 1]));
+        extractJoints(*model, *solution.back()),
+        start_state);
 
     // Break out the process path from the seed path and convert to ROS messages
-    DescartesTraj process_part(solved_path.begin() + to_process.size(),
-                               solved_path.end() - from_process.size());
-    trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *model);
-
-    for (std::size_t i = 0; i < process.points.size(); ++i)
-    {
-      const auto& pt = process.points[i];
-      if (!model->isValid(pt.positions))
-      {
-        ROS_WARN_STREAM("Position in blending path (" << i << ") invalid: Joint limit or collision detected\n");
-        return false;
-      }
-    }
-
+    trajectory_msgs::JointTrajectory process = toROSTrajectory(solution, *model);
 
     // Fill in result trajectories
     plan.trajectory_process = process;
@@ -114,4 +97,115 @@ bool godel_process_planning::generateMotionPlan(const descartes_core::RobotModel
     ROS_ERROR_STREAM("Exception caught when planning blending path: " << e.what());
     return false;
   }
+
+
+
+
+
+
+
+//  // Compute all of the joint poses at the start of the process path
+//  std::vector<std::vector<double> > start_joint_poses;
+//  traj.front()->getJointPoses(*model, start_joint_poses);
+
+//  if (start_joint_poses.empty())
+//  {
+//    ROS_WARN_STREAM("Blend Planning Service: Could not compute any inverse kinematic solutions for "
+//                    "the first point in the process path.");
+
+//    return false;
+//  }
+
+//  ROS_INFO_STREAM("Number of candidate poses: " << start_joint_poses.size());
+
+//  auto start_pose = godel_process_planning::pickBestStartPose(start_state, *model,
+//                                                              start_joint_poses,
+//                                                              freeSpaceCostFunction);
+
+//  DescartesTraj solved_path;
+//  // Calculate tool pose of robot starting config so that we can go back here on the
+//  // return move
+//  Eigen::Affine3d init_pose;
+//  model->getFK(start_state, init_pose);
+//  // Compute the nominal tool pose of the final process point
+//  Eigen::Affine3d process_stop_pose;
+//  traj.back()->getNominalCartPose(std::vector<double>(), *model,
+//                                  process_stop_pose);
+
+//  // Joint interpolate from the initial robot position to 'best' starting configuration of process
+//  // path
+//  DescartesTraj to_process = createJointPath(start_state, start_pose);
+//  to_process.front() =
+//      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
+
+//  // To get a rough estimate of process path cost, add a cartesian move from the final process point
+//  // to the starting position again.
+//  DescartesTraj from_process = createLinearPath(process_stop_pose, init_pose);
+//  from_process.back() =
+//      descartes_core::TrajectoryPtPtr(new descartes_trajectory::JointTrajectoryPt(start_state));
+
+//  // Affix the approach and depart paths calculated above with user process path
+//  DescartesTraj seed_path;
+//  seed_path.insert(seed_path.end(), to_process.begin(), to_process.end());
+//  seed_path.insert(seed_path.end(), traj.begin(), traj.end());
+//  seed_path.insert(seed_path.end(), from_process.begin(), from_process.end());
+
+//  // Attempt to solve the initial path (minimize joint motion over entire plan)
+//  if (!descartesSolve(seed_path, model, solved_path))
+//  {
+//    return false;
+//  }
+
+//  // Go back over and recalculate the approach and depart segments to:
+//  //  1. Use a joint interpolation from start to stop if collision free
+//  //  2. Use MoveIt (RRT-Connect) if the above fails
+//  // This is the only portion of the trajectory that is collision checked. Note this
+//  // method also converts the Descartes points into ROS trajectories.
+//  try
+//  {
+//    trajectory_msgs::JointTrajectory approach =
+//        planFreeMove(*model, move_group_name, moveit_model,
+//                     extractJoints(*model, *solved_path[0]),
+//                     extractJoints(*model, *solved_path[to_process.size()]));
+
+//    trajectory_msgs::JointTrajectory depart = planFreeMove(
+//        *model, move_group_name, moveit_model,
+//        extractJoints(*model, *solved_path[to_process.size() + traj.size() - 1]),
+//        extractJoints(*model, *solved_path[seed_path.size() - 1]));
+
+//    // Break out the process path from the seed path and convert to ROS messages
+//    DescartesTraj process_part(solved_path.begin() + to_process.size(),
+//                               solved_path.end() - from_process.size());
+//    trajectory_msgs::JointTrajectory process = toROSTrajectory(process_part, *model);
+
+//    for (std::size_t i = 0; i < process.points.size(); ++i)
+//    {
+//      const auto& pt = process.points[i];
+//      if (!model->isValid(pt.positions))
+//      {
+//        ROS_WARN_STREAM("Position in blending path (" << i << ") invalid: Joint limit or collision detected\n");
+//        return false;
+//      }
+//    }
+
+
+//    // Fill in result trajectories
+//    plan.trajectory_process = process;
+//    plan.trajectory_approach = approach;
+//    plan.trajectory_depart = depart;
+
+//    // Fill in result header information
+//    const std::vector<std::string>& joint_names =
+//        moveit_model->getJointModelGroup(move_group_name)->getActiveJointModelNames();
+
+//    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_approach);
+//    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_depart);
+//    godel_process_planning::fillTrajectoryHeaders(joint_names, plan.trajectory_process);
+//    return true;
+//  }
+//  catch (const std::runtime_error& e)
+//  {
+//    ROS_ERROR_STREAM("Exception caught when planning blending path: " << e.what());
+//    return false;
+//  }
 }

--- a/godel_process_planning/src/path_transitions.cpp
+++ b/godel_process_planning/src/path_transitions.cpp
@@ -163,6 +163,12 @@ godel_process_planning::toDescartesTraj(const std::vector<geometry_msgs::PoseArr
       // O(1) jerky - may need to revisit this time parameterization later. This at least allows
       // Descartes to perform some optimizations in its graph serach.
       double dt = (this_pose.translation() - last_pose.translation()).norm() / process_speed;
+
+      if (dt < 1e-4)
+      {
+        continue;
+      }
+
       if (j == poses.size() - 1 && free_last)
       {
         dt = 0.0;

--- a/godel_process_planning/src/trajectory_utils.cpp
+++ b/godel_process_planning/src/trajectory_utils.cpp
@@ -11,7 +11,7 @@ static unsigned int calculateRequiredSteps(const std::vector<double>& start,
   unsigned steps = 0;
   for (std::size_t i = 0; i < start.size(); ++i)
   {
-    unsigned this_joint_steps = static_cast<unsigned>(std::abs(start[i] - stop[i]) / dtheta);
+    unsigned this_joint_steps = static_cast<unsigned>(std::ceil(std::abs(start[i] - stop[i]) / dtheta));
     steps = std::max(steps, this_joint_steps);
   }
 


### PR DESCRIPTION
This PR relies on a custom version of Descartes. This is reflected by the updated rosinstall file.

Essentially, this PR is a first step along the path toward updating our whole motion planning pipeline.

Motion planning now works as follows:
 1. For the process path, build a graph of valid joint solutions and transitions
 2. For every point in the first 'row', the possible starting configurations, estimate a cost to get to them
 3. Seed a graph search with this estimated cost.
 4. Extract the minimum path.
 5. Check the joint interpolated solution and then call moveit if needed to get from and to the path.

I also throw in some extra checks to make sure we aren't crashing the robot when Descartes changes configurations. Implemented logic similar to min viable segment length from Moveit.

This is what you've been seeing running the past day or two.
