### PR TITLE
add collision model to irb2400 workcell

### DIFF
--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/urdf/irb2400_workspace.xacro
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/urdf/irb2400_workspace.xacro
@@ -2,13 +2,16 @@
 <robot name="irb2400_workspace" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find abb_irb2400_support)/urdf/irb2400_macro.xacro"/>
   <xacro:include filename="$(find blending_end_effector)/urdf/blending_eff_macro.xacro"/>
-  
+  <xacro:include filename="$(find godel_irb2400_support)/urdf/swri_demo_cell_macro.xacro"/>
+
   <link name="world_frame"/>
 
   <!-- instantiating arm  --> 
   <xacro:abb_irb2400 prefix=""/>
   <!-- instantiating end effector  -->
   <xacro:blending_eff_definition prefix=""/>
+
+  <xacro:swri_demo_cell prefix=""/>
 
   <!-- Attach the end effector to the end of the robot arm (tool0) -->
   <joint name="link_t_to_eff" type="fixed">
@@ -21,6 +24,12 @@
   <joint name="world_to_base" type="fixed">
     <parent link="world_frame"/>
     <child link="base_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
+  <joint name="world_to_demo_cell" type="fixed">
+    <parent link="world_frame"/>
+    <child link="demo_cell_base_link"/>
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </joint>
   

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/urdf/swri_demo_cell_macro.xacro
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/urdf/swri_demo_cell_macro.xacro
@@ -1,0 +1,119 @@
+<?xml version="1.0" ?>
+
+<!-- Exports macro: "xacro:swri_demo_cell" with 1 arg: prefix -->
+<!-- Root link: ${prefix}demo_cell_base_link -->
+<!-- Origin is at the robot (IRB 2400) mounting location -->
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:property name="demo_cell_width" value="1.8288"/> <!-- 60" table + 12" forward-->
+  <xacro:property name="demo_cell_length" value="1.524"/> <!--36" table + 12" left + 12" right -->
+  <xacro:property name="demo_cell_height" value="2.4384"/> <!--96"  vertical-->
+
+  <xacro:property name="robot_to_corner_x" value="-0.45"/> <!-- 17.7165" from back -->
+  <xacro:property name="robot_to_corner_y" value="-0.762"/> <!-- middle of width -->
+
+  <xacro:property name="demo_cell_wall_thickness" value="0.05"/>
+
+  <!--
+    The demo cell macro
+    * All uses of "left" and "right" are relative to an observer looking into the cage
+    * through the light curtains
+  -->
+  <xacro:macro name="swri_demo_cell" params="prefix">
+
+  <link name="${prefix}demo_cell_base_link" />
+
+  <link name="${prefix}demo_cell_corner"/>
+
+  <link name="${prefix}demo_cell_back_wall">
+    <collision>
+      <geometry>
+        <box size="${demo_cell_wall_thickness} ${demo_cell_length} ${demo_cell_height}"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="${prefix}demo_cell_right_wall">
+    <collision>
+      <geometry>
+        <box size="${demo_cell_width} ${demo_cell_wall_thickness} ${demo_cell_height}"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="${prefix}demo_cell_left_wall">
+    <collision>
+      <geometry>
+        <box size="${demo_cell_width} ${demo_cell_wall_thickness} ${demo_cell_height}"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <!-- light curtains -->
+  <link name="${prefix}demo_cell_front_wall">
+    <collision>
+      <geometry>
+        <box size="${demo_cell_wall_thickness} ${demo_cell_length} ${demo_cell_height}"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="${prefix}demo_cell_roof">
+    <collision>
+      <geometry>
+        <box size="${demo_cell_width} ${demo_cell_length} ${demo_cell_wall_thickness}"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <link name="${prefix}demo_cell_floor">
+    <collision>
+      <geometry>
+        <box size="${demo_cell_width} ${demo_cell_length} ${demo_cell_wall_thickness}"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="${prefix}cell_baselink_to_corner" type="fixed">
+    <parent link="${prefix}demo_cell_base_link"/>
+    <child link="${prefix}demo_cell_corner"/>
+    <origin xyz="${robot_to_corner_x} ${robot_to_corner_y} 0"/>
+  </joint>
+
+  <joint name="${prefix}cell_corner_to_back" type="fixed">
+    <parent link="${prefix}demo_cell_corner"/>
+    <child link="${prefix}demo_cell_back_wall"/>
+    <origin xyz="${-0.5 * demo_cell_wall_thickness} ${demo_cell_length / 2.0} ${demo_cell_height / 2.0}"/>
+  </joint>
+
+  <joint name="${prefix}cell_corner_to_left" type="fixed">
+    <parent link="${prefix}demo_cell_corner"/>
+    <child link="${prefix}demo_cell_left_wall"/>
+    <origin xyz="${demo_cell_width / 2.0} ${-0.5 * demo_cell_wall_thickness} ${demo_cell_height / 2.0}"/>
+  </joint>
+
+  <joint name="${prefix}cell_corner_to_front" type="fixed">
+    <parent link="${prefix}demo_cell_corner"/>
+    <child link="${prefix}demo_cell_front_wall"/>
+    <origin xyz="${demo_cell_width + 0.5 * demo_cell_wall_thickness} ${demo_cell_length / 2.0} ${demo_cell_height / 2.0}"/>
+  </joint>
+
+  <joint name="${prefix}cell_corner_to_right" type="fixed">
+    <parent link="${prefix}demo_cell_corner"/>
+    <child link="${prefix}demo_cell_right_wall"/>
+    <origin xyz="${demo_cell_width / 2.0} ${demo_cell_length + 0.5 * demo_cell_wall_thickness} ${demo_cell_height / 2.0}"/>
+  </joint>
+
+  <joint name="${prefix}cell_corner_to_roof" type="fixed">
+    <parent link="${prefix}demo_cell_corner"/>
+    <child link="${prefix}demo_cell_roof"/>
+    <origin xyz="${demo_cell_width / 2.0} ${demo_cell_length / 2.0} ${demo_cell_height + 0.5 * demo_cell_wall_thickness}"/>
+  </joint>
+
+  <joint name="${prefix}cell_corner_to_floor" type="fixed">
+    <parent link="${prefix}demo_cell_corner"/>
+    <child link="${prefix}demo_cell_floor"/>
+    <origin xyz="${demo_cell_width / 2.0} ${demo_cell_length / 2.0} ${-0.5 * demo_cell_wall_thickness}"/>
+  </joint>
+
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
I didn't want to run the robot with the automated gui for hours without a good collision model.  The new collision model is based on @Jmeyer1292's irb1200 workcell with the following parameters:
- length is table is table plus 12" on each side
- width is table plus 12" ahead of robot
- height is 96" arbitrarily.