### PR TITLE
Noether in the Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,6 @@ Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C
   catkin build
   ```
 
-- If you have issues regarding a missing `QD` library, then:
-  ```
-  sudo apt install libqd-dev
-  ```
-
 ### Applications
 
 - Run blending demo in full simulation mode (simulated robot and sensor)
@@ -56,10 +51,30 @@ Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C
   roslaunch godel_irb2400_support irb2400_blending.launch sim_sensor:=false 
   sim_robot:=false robot_ip:=[robot ip]
   ```
+
 ### Qt Glyph Loading Segfault (Kinetic)
+
 - Rviz on Kinetic is prone to a segmentation fault caused by internal functions in the Qt library. Our current work-around is to set the following environment variable:
   ```
   export QT_NO_FT_CACHE=1
+  ```
+
+### Planning and Meshing Plugins
+
+- The `meshing_plugins_base` and `path_planning_plugins_base` packages define the interfaces that Godel uses to both perform surface reconstruction
+  and tool path generation based on those reconstructions.
+
+- The current default mesher works well for point clouds regions that can be accurately modeled by a convex polygon. The default blending tool planner only works well for
+  planar meshes.
+
+- We are working on an experimental library for more arbitrary surface reconstruction and tool path planning in the [noether package](https://github.com/ros-industrial/noether.git).
+  - To use, first install the dependencies of noether, which include VTK 7.1 and PCL 1.8.
+  - Clone the [noether package](https://github.com/ros-industrial/noether.git) into your workspace.
+  - Clone the [godel_noether](https://github.com/Jmeyer1292/godel_noether) package in your workspace.
+  - In your godel robot support package, e.g. `godel_irb2400_support`, modify the config/plugins.yaml file to read:
+  ```
+    meshing_plugin_name: "godel_noether::NoetherMesher"
+    blend_tool_planning_plugin_name: "godel_noether::NoetherPathPlanner"
   ```
 
 ### Keyence Laser Scanner


### PR DESCRIPTION
Adds some instructions for using Noether with Godel.

Also removes an unneeded warning about libqd-dev.