### PR TITLE
add automate 2017 gif to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Application for demonstrating surface blending with ROS.
 
 Godel: Austrian logician and mathematician http://en.wikipedia.org/wiki/Kurt_G%C3%B6del
 
+![Automate 2017 Demo Video](https://s3-us-west-2.amazonaws.com/ros-industrial/gifs/ROS-I_Surface_Blending.gif)
+
 ### Installation
 
 - Install [wstool](http://wiki.ros.org/wstool) in order manage the repos inside the workspace


### PR DESCRIPTION
i added the following to the readme, but for some reason github is changing the URL in the actual readme...
```
![Automate 2017 Demo Video](https://s3-us-west-2.amazonaws.com/ros-industrial/gifs/ROS-I_Surface_Blending.gif)`
```
According to documentation and tested on markdown simulators the above should work.