### PR TITLE
Fix trajectory timestamp

### DIFF
--- a/godel/package.xml
+++ b/godel/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>godel_plugins</exec_depend>
-  <exec_depend>godel_path_planning</exec_depend>
+  <exec_depend>godel_process_planning</exec_depend>
   <exec_depend>godel_process_path_generation</exec_depend>
   <exec_depend>godel_msgs</exec_depend>
   <exec_depend>godel_surface_detection</exec_depend>

--- a/godel_process_execution/src/blend_process_service.cpp
+++ b/godel_process_execution/src/blend_process_service.cpp
@@ -47,6 +47,10 @@ void godel_process_execution::BlendProcessService::executionCallback(
 bool godel_process_execution::BlendProcessService::executeProcess(
     const godel_msgs::ProcessExecutionGoalConstPtr &goal)
 {
+  //goal->trajectory_approach.header.stamp = ros::Time::now();
+  //goal->trajectory_depart.header.stamp = ros::Time::now();
+  //goal->trajectory_process.header.stamp = ros::Time::now();
+
   godel_msgs::TrajectoryExecution srv_approach;
   srv_approach.request.wait_for_execution = true;
   srv_approach.request.trajectory = goal->trajectory_approach;
@@ -59,18 +63,21 @@ bool godel_process_execution::BlendProcessService::executeProcess(
   srv_depart.request.wait_for_execution = true;
   srv_depart.request.trajectory = goal->trajectory_depart;
 
+  srv_approach.request.trajectory.header.stamp = ros::Time::now();
   if (!real_client_.call(srv_approach))
   {
     ROS_ERROR("Execution client unavailable or unable to execute approach trajectory.");
     return false;
   }
 
+  srv_process.request.trajectory.header.stamp = ros::Time::now();
   if (!real_client_.call(srv_process))
   {
     ROS_ERROR("Execution client unavailable or unable to execute process trajectory.");
     return false;
   }
 
+  srv_depart.request.trajectory.header.stamp = ros::Time::now();
   if (!real_client_.call(srv_depart))
   {
     ROS_ERROR("Execution client unavailable or unable to execute departure trajectory.");

--- a/godel_process_execution/src/blend_process_service.cpp
+++ b/godel_process_execution/src/blend_process_service.cpp
@@ -47,10 +47,6 @@ void godel_process_execution::BlendProcessService::executionCallback(
 bool godel_process_execution::BlendProcessService::executeProcess(
     const godel_msgs::ProcessExecutionGoalConstPtr &goal)
 {
-  //goal->trajectory_approach.header.stamp = ros::Time::now();
-  //goal->trajectory_depart.header.stamp = ros::Time::now();
-  //goal->trajectory_process.header.stamp = ros::Time::now();
-
   godel_msgs::TrajectoryExecution srv_approach;
   srv_approach.request.wait_for_execution = true;
   srv_approach.request.trajectory = goal->trajectory_approach;

--- a/godel_surface_detection/src/scan/robot_scan.cpp
+++ b/godel_surface_detection/src/scan/robot_scan.cpp
@@ -172,7 +172,7 @@ void RobotScan::publish_scan_poses(std::string topic)
 bool RobotScan::move_to_pose(geometry_msgs::Pose& target_pose)
 {
   move_group_ptr_->setPoseTarget(target_pose, params_.tcp_frame);
-  return move_group_ptr_->move();
+  return static_cast<bool>(move_group_ptr_->move());
 }
 
 int RobotScan::scan(bool move_only)
@@ -223,7 +223,7 @@ int RobotScan::scan(bool move_only)
 //      move_group_ptr_->setPoseTarget(trajectory_poses[i], params_.tcp_frame);
 
       moveit::planning_interface::MoveGroupInterface::Plan my_plan;
-      bool success = move_group_ptr_->plan(my_plan);
+      bool success = static_cast<bool>(move_group_ptr_->plan(my_plan));
 
       if (!success)
       {


### PR DESCRIPTION
I am not sure if this is the best solution for the following errors I am getting: 

"Execution client unavailable or unable to execute approach trajectory."
"Dropping all trajectory point(s) out of 30, as they occur before the current time"

The original repo works with fake_controllers. But I am testing it Gazebo with JointTrajectoryController when I get these errors. Let me know if there is better solution.