### PR TITLE
Add param for vel scaling of the scan movement

### DIFF
--- a/godel_msgs/msg/RobotScanParameters.msg
+++ b/godel_msgs/msg/RobotScanParameters.msg
@@ -1,5 +1,6 @@
 # path planning
 string group_name
+float64 move_scan_vel_scaling
 string home_position
 string world_frame
 string tcp_frame

--- a/godel_plugins/src/widgets/robot_scan_configuration.cpp
+++ b/godel_plugins/src/widgets/robot_scan_configuration.cpp
@@ -82,6 +82,7 @@ void godel_plugins::RobotScanConfigWidget::update_gui_fields()
   ui_.LineEditWorldFrame->setText(QString::fromStdString(params_.world_frame));
   ui_.LineEditTcpFrame->setText(QString::fromStdString(params_.tcp_frame));
   ui_.LineEditGroupName->setText(QString::fromStdString(params_.group_name));
+  ui_.LineEditMoveScanVelScaling->setText(QString::number(params_.move_scan_vel_scaling));
   ui_.CheckBoxStopOnPlanningError->setChecked(params_.stop_on_planning_error);
 
   world_to_obj_pose_widget_->set_values(params_.world_to_obj_pose);
@@ -102,6 +103,7 @@ void godel_plugins::RobotScanConfigWidget::update_internal_values()
   params_.world_frame = ui_.LineEditWorldFrame->text().toStdString();
   params_.tcp_frame = ui_.LineEditTcpFrame->text().toStdString();
   params_.group_name = ui_.LineEditGroupName->text().toStdString();
+  params_.move_scan_vel_scaling = ui_.LineEditMoveScanVelScaling->text().toDouble();
   params_.stop_on_planning_error = ui_.CheckBoxStopOnPlanningError->isChecked();
 
   tf::poseTFToMsg(world_to_obj_pose_widget_->get_values(), params_.world_to_obj_pose);

--- a/godel_plugins/src/widgets/robot_scan_configuration.ui
+++ b/godel_plugins/src/widgets/robot_scan_configuration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>540</width>
-    <height>563</height>
+    <height>583</height>
    </rect>
   </property>
   <property name="font">
@@ -105,7 +105,7 @@
       <x>30</x>
       <y>40</y>
       <width>281</width>
-      <height>441</height>
+      <height>461</height>
      </rect>
     </property>
     <property name="frameShape">
@@ -299,13 +299,36 @@
        </widget>
       </item>
       <item row="12" column="0">
+       <widget class="QLabel" name="moveScanVelScalingLabel">
+        <property name="text">
+         <string>Move Scan Vel Scaling</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QLineEdit" name="LineEditMoveScanVelScaling">
+        <property name="inputMethodHints">
+         <set>Qt::ImhDigitsOnly</set>
+        </property>
+        <property name="inputMask">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="maxLength">
+         <number>8</number>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
        <widget class="QLabel" name="stopOnPlanningErrorLabel">
         <property name="text">
          <string>Stop On Plan Error</string>
         </property>
        </widget>
       </item>
-      <item row="12" column="1">
+      <item row="13" column="1">
        <widget class="QCheckBox" name="CheckBoxStopOnPlanningError"/>
       </item>
      </layout>
@@ -341,7 +364,7 @@
     <property name="geometry">
      <rect>
       <x>33</x>
-      <y>500</y>
+      <y>520</y>
       <width>491</width>
       <height>33</height>
      </rect>

--- a/godel_robots/abb/godel_irb1200/godel_irb1200_support/config/robot_scan.yaml
+++ b/godel_robots/abb/godel_irb1200/godel_irb1200_support/config/robot_scan.yaml
@@ -1,5 +1,6 @@
 robot_scan:
   group_name: manipulator_asus
+  move_scan_vel_scaling: 1
   home_position: home_asus
   world_frame: world_frame
   tcp_frame: kinect2_move_frame

--- a/godel_robots/abb/godel_irb2400/godel_irb2400_support/config/robot_scan.yaml
+++ b/godel_robots/abb/godel_irb2400/godel_irb2400_support/config/robot_scan.yaml
@@ -1,5 +1,6 @@
 robot_scan:
   group_name: manipulator_asus
+  move_scan_vel_scaling: 1
   home_position: home_asus
   world_frame: world_frame
   tcp_frame: kinect2_move_frame

--- a/godel_simple_gui/src/options/robot_scan_configuration.cpp
+++ b/godel_simple_gui/src/options/robot_scan_configuration.cpp
@@ -40,6 +40,7 @@ void godel_simple_gui::RobotScanConfigWidget::update_display_fields()
   ui_->LineEditWorldFrame->setText(QString::fromStdString(params_.world_frame));
   ui_->LineEditTcpFrame->setText(QString::fromStdString(params_.tcp_frame));
   ui_->LineEditGroupName->setText(QString::fromStdString(params_.group_name));
+  ui_->LineEditMoveScanVelScaling->setText(QString::number(params_.move_scan_vel_scaling));
   ui_->CheckBoxStopOnPlanningError->setChecked(params_.stop_on_planning_error);
 
   world_to_obj_pose_widget_->set_values(params_.world_to_obj_pose);
@@ -60,6 +61,7 @@ void godel_simple_gui::RobotScanConfigWidget::update_internal_fields()
   params_.world_frame = ui_->LineEditWorldFrame->text().toStdString();
   params_.tcp_frame = ui_->LineEditTcpFrame->text().toStdString();
   params_.group_name = ui_->LineEditGroupName->text().toStdString();
+  params_.move_scan_vel_scaling = ui_->LineEditMoveScanVelScaling->text().toDouble();
   params_.stop_on_planning_error = ui_->CheckBoxStopOnPlanningError->isChecked();
 
   tf::poseTFToMsg(world_to_obj_pose_widget_->get_values(), params_.world_to_obj_pose);

--- a/godel_simple_gui/src/uis/robot_scan_configuration.ui
+++ b/godel_simple_gui/src/uis/robot_scan_configuration.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>540</width>
-    <height>563</height>
+    <height>583</height>
    </rect>
   </property>
   <property name="font">
@@ -105,7 +105,7 @@
       <x>30</x>
       <y>40</y>
       <width>281</width>
-      <height>441</height>
+      <height>461</height>
      </rect>
     </property>
     <property name="frameShape">
@@ -299,13 +299,36 @@
        </widget>
       </item>
       <item row="12" column="0">
+       <widget class="QLabel" name="moveScanVelScalingLabel">
+        <property name="text">
+         <string>Move Scan Vel Scaling</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QLineEdit" name="LineEditMoveScanVelScaling">
+        <property name="inputMethodHints">
+         <set>Qt::ImhDigitsOnly</set>
+        </property>
+        <property name="inputMask">
+         <string/>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="maxLength">
+         <number>8</number>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
        <widget class="QLabel" name="stopOnPlanningErrorLabel">
         <property name="text">
          <string>Stop On Plan Error</string>
         </property>
        </widget>
       </item>
-      <item row="12" column="1">
+      <item row="13" column="1">
        <widget class="QCheckBox" name="CheckBoxStopOnPlanningError"/>
       </item>
      </layout>
@@ -341,7 +364,7 @@
     <property name="geometry">
      <rect>
       <x>33</x>
-      <y>500</y>
+      <y>520</y>
       <width>491</width>
       <height>33</height>
      </rect>

--- a/godel_surface_detection/src/scan/robot_scan.cpp
+++ b/godel_surface_detection/src/scan/robot_scan.cpp
@@ -55,6 +55,7 @@ RobotScan::RobotScan()
 {
 
   params_.group_name = "manipulator_asus";
+  params_.move_scan_vel_scaling = 1;
   params_.home_position = "home";
   params_.world_frame = "world_frame";
   params_.tcp_frame = "kinect2_move_frame";
@@ -75,6 +76,7 @@ RobotScan::RobotScan()
 bool RobotScan::init()
 {
   move_group_ptr_ = MoveGroupPtr(new  moveit::planning_interface::MoveGroupInterface(params_.group_name));
+  move_group_ptr_->setMaxVelocityScalingFactor(params_.move_scan_vel_scaling);
   move_group_ptr_->setEndEffectorLink(params_.tcp_frame);
   move_group_ptr_->setPoseReferenceFrame(params_.world_frame);
   move_group_ptr_->setPlanningTime(PLANNING_TIME);
@@ -97,6 +99,7 @@ bool RobotScan::load_parameters(const std::string& filename)
   // otherwise load from parameters
   ros::NodeHandle nh("~/robot_scan");
   return loadParam(nh, "group_name", params_.group_name) &&
+         loadParam(nh, "move_scan_vel_scaling", params_.move_scan_vel_scaling) &&
          loadParam(nh, "home_position", params_.home_position) &&
          loadParam(nh, "world_frame", params_.world_frame) &&
          loadParam(nh, "tcp_frame", params_.tcp_frame) &&
@@ -361,6 +364,7 @@ bool RobotScan::create_scan_trajectory(std::vector<geometry_msgs::Pose>& scan_po
     scan_poses.push_back(pose);
   }
 
+  move_group_ptr_->setMaxVelocityScalingFactor(params_.move_scan_vel_scaling);
   move_group_ptr_->setEndEffectorLink(params_.tcp_frame);
 
   return true;


### PR DESCRIPTION
- The new parameter uses `setMaxVelocityScalingFactor()` to set the scaling of the velocity for the movement to/between the scan points.
- The function is called with the parameter in the `RobotScan::init()` function. This is actually not required because of the next bullet-point. However, I left it to be consistent with the other params like e.g. `move_group_ptr_->setMaxVelocityScalingFactor(params_.move_scan_vel_scaling);`

- I also added this function to the `RobotScan::create_scan_trajectory(...)` function. So if one changes the parameter in the gui, it is applied for the next scan process. `setEndEffectorLink(params_.tcp_frame)`
- Parameter got added in the `RobotScanParameters.msg`
- I set the default value and the one in `robot_scan.yaml(s)` to `1`, which applies no scaling
- Added the parameter to the gui(s)
- Had to increase the hight of the gui(s) to make space for the new field

![image](https://user-images.githubusercontent.com/17281534/40053068-2c2967c0-5840-11e8-817b-76b517bdb3fc.png)
